### PR TITLE
Adding conditions to ActiveHash#all

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gem "rspec", ">= 1.3.0"
 gem "fixjour", "0.4.1"
 gem "jeweler", "1.4.0"
 gem "sqlite3-ruby", ">= 1.2.5"
+gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
       git (>= 1.2.5)
       rubyforge (>= 2.0.0)
     json_pure (1.4.6)
+    rake (0.8.7)
     rspec (1.3.0)
     rubyforge (2.0.4)
       json_pure (>= 1.1.7)
@@ -26,5 +27,6 @@ DEPENDENCIES
   activesupport (= 2.3.8)
   fixjour (= 0.4.1)
   jeweler (= 1.4.0)
+  rake
   rspec (>= 1.3.0)
   sqlite3-ruby (>= 1.2.5)

--- a/lib/active_file/base.rb
+++ b/lib/active_file/base.rb
@@ -5,7 +5,7 @@ module ActiveFile
 
     class << self
 
-      def all
+      def all(options={})
         reload unless data_loaded
         super
       end

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -57,8 +57,14 @@ module ActiveHash
         record
       end
 
-      def all
-        @records || []
+      def all(options={})
+        if options.has_key?(:conditions)
+          (@records || []).select do |record|
+            options[:conditions].all? {|col, match| record[col] == match}
+          end
+        else
+          @records || []
+        end
       end
 
       def count

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -137,6 +137,13 @@ describe ActiveHash, "Base" do
       records.first.name.should == "Canada"
       records.length.should == 1
     end
+    
+    it "filters the records from a AR-like conditions hash" do
+      record = Country.all(:conditions => {:name => 'US'})
+      record.count.should == 1
+      record.first.id.should == 1
+      record.first.name.should == 'US'
+    end
   end
 
   describe ".count" do


### PR DESCRIPTION
I ran in to some conflicts using ActiveHash with Formtastic since it passed an options has to #all assuming the model is an ActiveRecord.  This broke ActiveHash since it doesn't take any params for #all.  I went one step further and has it actually do a select on the records if there was a :conditions key.  It only handles conditions as a hash.
