### PR TITLE
Remove dependency on i18n

### DIFF
--- a/lib/active_hash.rb
+++ b/lib/active_hash.rb
@@ -1,7 +1,7 @@
 require 'active_support'
 
 begin
-  require 'active_support/all'
+  require 'active_support/core_ext'
 rescue MissingSourceFile
 end
 


### PR DESCRIPTION
`active_hash` currently requires `active_support/all`, which raises an error if the `i18n` gem is not in the `Gemfile` of the application using `active_hash`.

Since only the portions of `active_support` loaded with `active_support/core_ext` are used in `active_hash`, this commit replaces `active_support/all` with `active_support/core_ext`, thus removing the unnecessary `i18n` requirement.
