### PR TITLE
Adding test, and patch, for setting a belongs_to_active_hash association 

### DIFF
--- a/lib/associations/associations.rb
+++ b/lib/associations/associations.rb
@@ -14,7 +14,7 @@ module ActiveHash
         end
 
         define_method("#{association_id}=") do |new_value|
-          attributes[options[:foreign_key].to_sym] = new_value ? new_value.id : nil
+          send "#{options[:foreign_key]}=", new_value ? new_value.id : nil
         end
       end
 

--- a/spec/associations/associations_spec.rb
+++ b/spec/associations/associations_spec.rb
@@ -97,20 +97,36 @@ describe ActiveHash::Base, "associations" do
   describe ActiveHash::Associations::ActiveRecordExtensions do
 
     describe "#belongs_to_active_hash" do
-      it "finds the correct records" do
-        School.belongs_to_active_hash :city
-        city = City.create
-        school = School.create :city_id => city.id
-        school.city.should == city
+      context "setting by id" do
+        it "finds the correct records" do
+          School.belongs_to_active_hash :city
+          city = City.create
+          school = School.create :city_id => city.id
+          school.city.should == city
+        end
+
+        it "returns nil when the record does not exist" do
+          School.belongs_to_active_hash :city
+          school = School.create! :city_id => nil
+          school.city.should be_nil
+        end
       end
 
-      it "returns nil when the record does not exist" do
-        School.belongs_to_active_hash :city
-        school = School.create! :city_id => nil
-        school.city.should be_nil
+      context "setting by association" do
+        it "finds the correct records" do
+          School.belongs_to_active_hash :city
+          city = City.create
+          school = School.create :city => city
+          school.city.should == city
+        end
+
+        it "returns nil when the record does not exist" do
+          School.belongs_to_active_hash :city
+          school = School.create! :city => nil
+          school.city.should be_nil
+        end
       end
     end
-
   end
 
   describe "#belongs_to" do


### PR DESCRIPTION
Adding test, and patch, for setting a belongs_to_active_hash association by association (not id).

I know I _could_ apply this directly to the repo, since I'm a committer, but want to make sure somebody reviews, since I did it in a hurry. Thanks.
