### PR TITLE
add associations to active record associations

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -1,3 +1,4 @@
+require 'active_record'
 module ActiveHash
 
   class RecordNotFound < StandardError
@@ -23,8 +24,16 @@ module ActiveHash
       end
     end
 
+    include ActiveRecord::Reflection
+
     class << self
 
+      def compute_type(*args)
+        self
+      end
+      def pluralize_table_names
+        true
+      end
       def primary_key
         "id"
       end

--- a/spec/associations/associations_spec.rb
+++ b/spec/associations/associations_spec.rb
@@ -69,6 +69,13 @@ describe ActiveHash::Base, "associations" do
         author = Author.create :id => 1
         author.books.published.should == [@included_book_1]
       end
+
+      it "finds active record metadata for this association" do
+        Author.has_many :books
+        association = Author.reflect_on_association(:books)
+        association.should_not be_nil
+        association.klass.name.should == Book.name
+      end
     end
 
     context "with ActiveHash children" do
@@ -90,6 +97,14 @@ describe ActiveHash::Base, "associations" do
         city = City.create :id => 1
         city.writers.should == [@included_author_1, @included_author_2]
       end
+
+      it "finds active record metadata for this association" do
+        City.has_many :writers, :class_name => "Author"
+        City.reflect_on_all_associations.map(&:name).should == [:writers]
+        association = City.reflect_on_association(:writers)
+        association.should_not be_nil
+        association.klass.name.should == Author.name
+      end
     end
 
   end
@@ -110,6 +125,13 @@ describe ActiveHash::Base, "associations" do
           school = School.create! :city_id => nil
           school.city.should be_nil
         end
+
+        it "finds active record metadata for this association" do
+          School.belongs_to_active_hash :city
+          association = School.reflect_on_association(:city)
+          association.should_not be_nil
+          association.klass.name.should == City.name
+        end
       end
 
       context "setting by association" do
@@ -125,6 +147,13 @@ describe ActiveHash::Base, "associations" do
           school = School.create! :city => nil
           school.city.should be_nil
         end
+      end
+
+      it "finds active record metadata for this association" do
+        School.belongs_to_active_hash :city
+        association = School.reflect_on_association(:city)
+        association.should_not be_nil
+        association.klass.name.should == City.name
       end
     end
   end
@@ -143,6 +172,13 @@ describe ActiveHash::Base, "associations" do
         City.belongs_to :country
         city = City.create :country_id => 123
         city.country.should be_nil
+      end
+
+      it "finds active record metadata for this association" do
+        City.belongs_to :country
+        association = City.reflect_on_association(:country)
+        association.should_not be_nil
+        association.klass.name.should == Country.name
       end
     end
 


### PR DESCRIPTION
Hello,

This patch changes belongs_to_active_hash to populate active record's associations.

This association is used by simple form (and others) to build drop downs.

Good:
This patch worked in ree,1.9.2: rails 2.x - 3.x. (Could not test 1.8.7, but see no problem)

Bad:
It uses an active record model since ar uses is_a? in the code.

Please send any suggestions for the code/tests, and I'll change accordingly.

Thanks,
Keenan
