### PR TITLE
belongs_to_active_hash respects active record's association interface

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -39,6 +39,14 @@ module ActiveHash
         end
       end
 
+      def compute_type(type_name)
+        self
+      end
+
+      def pluralize_table_names
+        true
+      end
+
       def data
         _data
       end

--- a/lib/associations/associations.rb
+++ b/lib/associations/associations.rb
@@ -16,6 +16,13 @@ module ActiveHash
         define_method("#{association_id}=") do |new_value|
           send "#{options[:foreign_key]}=", new_value ? new_value.id : nil
         end
+
+        create_reflection(
+            :belongs_to,
+            association_id.to_sym,
+            options,
+            options[:class_name].constantize
+            )
       end
 
     end

--- a/spec/associations/associations_spec.rb
+++ b/spec/associations/associations_spec.rb
@@ -126,6 +126,13 @@ describe ActiveHash::Base, "associations" do
           school.city.should be_nil
         end
       end
+
+      it "finds active record metadata for this association" do
+        School.belongs_to_active_hash :city
+        association = School.reflect_on_association(:city)
+        association.should_not be_nil
+        association.klass.name.should == City.name
+      end
     end
   end
 


### PR DESCRIPTION
Hello,

Lets try this one again.

belongs_to adds metadata to a parent active record model.
Form builders (e.g.: simple form) use this metadata.

After this patch, belongs_to_active_hash will act the same way as belongs_to. It will also add the metadata.

I only need this functionality in ActiveRecord::Base children and not ActiveHash::Base classes. Hence I am only modifying belongs_to_active_hash.

If you want, I can add a respond_to?(:create_reflection).

Thanks,
--Keenan
