### PR TITLE
Validate uniqueness of IDs

### DIFF
--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -198,7 +198,7 @@ describe ActiveHash, "Base" do
       Country.data = [
         {:id => 1, :name => "US", :language => 'English'},
         {:id => 2, :name => "Canada", :language => 'English'},
-        {:id => 2, :name => "Mexico", :language => 'Spanish'}
+        {:id => 3, :name => "Mexico", :language => 'Spanish'}
       ]
     end
 
@@ -235,6 +235,16 @@ describe ActiveHash, "Base" do
       record.count.should == 1
       record.first.id.should == 1
       record.first.name.should == 'US'
+    end
+
+    it "raises an error if ids aren't unique" do
+      proc do
+        Country.data = [
+          {:id => 1, :name => "US", :language => 'English'},
+          {:id => 2, :name => "Canada", :language => 'English'},
+          {:id => 2, :name => "Mexico", :language => 'Spanish'}
+        ]
+      end.should raise_error(ActiveHash::IdError)
     end
   end
 


### PR DESCRIPTION
Hey, I noticed a bug in the tests where two records are created with the same id.  This breaks Active Hash's ability to find unique records by id, so I fixed the test and implemented a cache to check if the new record's id is already present.  This cache would be superseded by the revised data structure we discussed offline, but I wanted to submit a patch while those details are worked out.
