### PR TITLE
I want to be able to have ActiveHash classes ending with an 's' (such as 'SchoolStatus')

### DIFF
--- a/lib/associations/associations.rb
+++ b/lib/associations/associations.rb
@@ -5,7 +5,7 @@ module ActiveHash
 
       def belongs_to_active_hash(association_id, options = {})
         options = {
-          :class_name => association_id.to_s.classify,
+          :class_name => association_id.to_s.camelize,
           :foreign_key => association_id.to_s.foreign_key
         }.merge(options)
 

--- a/spec/associations/associations_spec.rb
+++ b/spec/associations/associations_spec.rb
@@ -26,6 +26,9 @@ describe ActiveHash::Base, "associations" do
       include ActiveHash::Associations
     end
 
+    class SchoolStatus < ActiveHash::Base
+    end
+
     class Book < ActiveRecord::Base
       establish_connection :adapter => "sqlite3", :database => ":memory:"
       connection.create_table(:books, :force => true) do |t|
@@ -132,6 +135,13 @@ describe ActiveHash::Base, "associations" do
         association = School.reflect_on_association(:city)
         association.should_not be_nil
         association.klass.name.should == City.name
+      end
+
+      it "handles classes ending with an 's'" do
+        School.belongs_to_active_hash :school_status
+        association = School.reflect_on_association(:school_status)
+        association.should_not be_nil
+        association.klass.name.should == SchoolStatus.name
       end
     end
   end


### PR DESCRIPTION
String#classify do not handles singular names correctly (see http://apidock.com/rails/String/classify).
