### PR TITLE
Fix find_by_id and find method returning nil unless .all called before

### DIFF
--- a/lib/active_file/base.rb
+++ b/lib/active_file/base.rb
@@ -54,6 +54,16 @@ module ActiveFile
         raise "Override Me"
       end
 
+      def find(*args)
+        reload unless data_loaded
+        return super
+      end
+
+      def find_by_id(*args)
+        reload unless data_loaded
+        return super
+      end
+
       protected :extension
 
     end

--- a/spec/active_yaml/base_spec.rb
+++ b/spec/active_yaml/base_spec.rb
@@ -82,4 +82,22 @@ describe ActiveYaml::Base do
 
   end
 
+  describe 'ID finders without reliance on a call to all, even with fields specified' do
+
+    before do
+      class City < ActiveYaml::Base
+        fields :id, :state, :name
+      end
+    end
+
+    it 'returns a single city based on #find' do
+      City.find(1).name.should == 'Albany'
+    end
+
+    it 'returns a single city based on find_by_id' do
+      City.find_by_id(1).name.should == 'Albany'
+    end
+
+  end
+
 end


### PR DESCRIPTION
Fix find_by_id and find method returning nil unless .all called beforehand for ActiveYaml or ActiveFile

This problem is related to this issue, https://github.com/zilkey/active_hash/pull/52, however it's not necessarily a fix.  Fundamentally the way ActiveFile inherits from ActiveHash is a little wrong as there is no way to inject data beforehand.
