### PR TITLE
Allow yaml aliases

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -62,7 +62,7 @@ module ActiveHash
         if array_of_hashes
           auto_assign_fields(array_of_hashes)
           array_of_hashes.each do |hash|
-            insert new(hash)
+            insert new(hash) if hash.kind_of? Hash
           end
         end
       end
@@ -311,12 +311,9 @@ module ActiveHash
 
       def auto_assign_fields(array_of_hashes)
         (array_of_hashes || []).inject([]) do |array, row|
-          next [] unless row.kind_of?( Hash ) # Allow a non-hash at the beginning for YAML aliases
-          row.symbolize_keys!
-          row.keys.each do |key|
-            unless key.to_s == "id"
-              array << key
-            end
+          if row.kind_of? Hash # Allow a non-hash for YAML aliases
+            row.symbolize_keys!
+            row.keys.each { |key| array << key unless key.to_s == "id" }
           end
           array
         end.uniq.each do |key|
@@ -368,6 +365,7 @@ module ActiveHash
     attr_reader :attributes
 
     def initialize(attributes = {})
+      return nil unless attributes.kind_of? Hash
       attributes.symbolize_keys!
       @attributes = attributes
       attributes.dup.each do |key, value|


### PR DESCRIPTION
## Allow YAML aliases in Active_Hash data

For example:

``` yaml
/aliases:
   -
      basic_permissions: &basic_permissions
      - view anything
      - create task
      - create update
      - create comment

      manager_permissions: &manager_permissions
      - create user

trial:
   id: 1
   permissions:
      - *basic_permissions
      - create project
```
