### PR TITLE
Allow YAML aliases in ActiveYaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ActiveHash also ships with:
 ## Installation
 
 Make sure gemcutter.org is one of your gem sources, then run:
-    
+
     sudo gem install active_hash
 
 ## Usage
@@ -314,6 +314,41 @@ Since ActiveYaml just creates a hash from the YAML file, you will have all field
     mexico:
       id: 3
       name: Mexico
+
+### Using aliases in YAML
+
+Aliases can be used in ActiveYaml using either array or hash style.
+Keys beginning with a '/' character can be safely added, and will be ignored, allowing you to add aliases anywhere in your code:
+
+    # Array Style
+    - /aliases:
+      soda_flavor: &soda_flavor
+        sweet
+      soda_price: &soda_price
+        1.0
+
+    - id: 1
+      name: Coke
+      flavor: *soda_flavor
+      price: *soda_price
+
+
+     # Key style
+    /aliases:
+      soda_flavor: &soda_flavor
+        sweet
+      soda_price: &soda_price
+        1.0
+
+    coke:
+      id: 1
+      name: Coke
+      flavor: *soda_flavor
+      price: *soda_price
+
+
+__ WARNING: ActiveYaml will ignore any hash containing a key beginning with the '/' character, to allow for YAML aliases__
+
 
 ## ActiveFile
 

--- a/lib/active_yaml/base.rb
+++ b/lib/active_yaml/base.rb
@@ -11,14 +11,23 @@ module ActiveYaml
       end
 
       def raw_data
-        YAML.load_file(full_path)
+        YAML.load_file(full_path).reject do |k,v|
+          v.kind_of? Hash and k.match /^\//i
+        end # Reject hashes with keys starting with '/', as these are YAML aliases
       end
 
       def extension
         "yml"
       end
 
+      def insert(record)
+        super if record.attributes.present?
+      end # Some records may have all attributes filtered out (aliases), so we ignore them
     end
+
+    def initialize(attributes={})
+      super unless attributes.keys.index{ |k| k.match /^\//i }
+    end # Remove all attributes whose key starts with '/' as these are YAML aliases
   end
 
 end

--- a/spec/fixtures/array_products.yml
+++ b/spec/fixtures/array_products.yml
@@ -1,0 +1,29 @@
+- /aliases:
+  soda_flavor: &soda_flavor
+    sweet
+  soda_price: &soda_price
+    1.0
+  chip_flavor: &chip_flavor
+    salty
+  chip_price: &chip_price
+    1.5
+
+- id: 1
+  name: Coke
+  flavor: *soda_flavor
+  price: *soda_price
+
+- id: 2
+  name: Pepsi
+  flavor: *soda_flavor
+  price: *soda_price
+
+- id: 3
+  name: Pringles
+  flavor: *chip_flavor
+  price: *chip_price
+
+- id: 4
+  name: ETA
+  flavor: *chip_flavor
+  price: *chip_price

--- a/spec/fixtures/key_products.yml
+++ b/spec/fixtures/key_products.yml
@@ -1,0 +1,35 @@
+/aliases:
+  soda_flavor: &soda_flavor
+    sweet
+  soda_price: &soda_price
+    1.0
+  chip_flavor: &chip_flavor
+    salty
+  chip_price: &chip_price
+    1.5
+
+
+coke:
+  id: 1
+  name: Coke
+  flavor: *soda_flavor
+  price: *soda_price
+
+pepsi:
+  id: 2
+  name: Pepsi
+  flavor: *soda_flavor
+  price: *soda_price
+
+pringles:
+  id: 3
+  name: Pringles
+  flavor: *chip_flavor
+  price: *chip_price
+  slogan: &inner_alias
+
+eta:
+  id: 4
+  name: ETA
+  flavor: *chip_flavor
+  price: *chip_price


### PR DESCRIPTION
Allow YAML aliases in ActiveYaml.

ActiveYaml will filter any arrays with keys whose first character is the '/' forward slash.
This allows users to create root elements in the YAML in which aliases can be stored nicely.
Tested with both array and key rows.

Aliases can be used like follows:

```
 - /aliases:
  soda_flavor: &soda_flavor
    sweet
  soda_price: &soda_price
    1.0

- id: 1
  name: Coke
  flavor: *soda_flavor
  price: *soda_price
```
