### PR TITLE
Preload the schema when finder methods called on ActiveHash

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ By default, this class will look for a yml file named "countries.yml" in the sam
 
 The above example will look for the file "/u/data/sample.yml".
 
-Since ActiveYaml just creates a hash from the YAML file, you will have all fields specified in YAML auto-defined for you once you call all.  You can format your YAML as an array, or as a hash:
+Since ActiveYaml just creates a hash from the YAML file, you will have all fields specified in YAML auto-defined for you.  You can format your YAML as an array, or as a hash:
 
     # array style
     - id: 1

--- a/lib/active_file/base.rb
+++ b/lib/active_file/base.rb
@@ -10,16 +10,6 @@ module ActiveFile
 
     class << self
 
-      def all(options={})
-        reload unless data_loaded
-        super
-      end
-
-      def where(options)
-        reload unless data_loaded
-        super
-      end
-
       def delete_all
         self.data_loaded = true
         super
@@ -53,18 +43,14 @@ module ActiveFile
       def extension
         raise "Override Me"
       end
-
-      def find(*args)
-        reload unless data_loaded
-        return super
-      end
-
-      def find_by_id(*args)
-        reload unless data_loaded
-        return super
-      end
-
       protected :extension
+
+      [:find, :find_by_id, :all, :where, :method_missing].each do |method|
+        define_method(method) do |*args|
+          reload unless data_loaded
+          return super(*args)
+        end
+      end
 
     end
   end

--- a/spec/active_yaml/base_spec.rb
+++ b/spec/active_yaml/base_spec.rb
@@ -27,6 +27,15 @@ describe ActiveYaml::Base do
     end
   end
 
+  describe ".where" do
+    context "before the file is loaded" do
+      it "reads from the file and filters by where statement" do
+        State.where(:name => 'Oregon').should_not be_empty
+        State.count.should > 0
+      end
+    end
+  end
+
   describe ".delete_all" do
     context "when called before .all" do
       it "causes all to not load data" do
@@ -91,6 +100,18 @@ describe ActiveYaml::Base do
 
     it 'returns a single city based on find_by_id' do
       City.find_by_id(1).name.should == 'Albany'
+    end
+
+  end
+
+  describe 'meta programmed finders and properties for fields that exist in the YAML' do
+
+    it 'should have a finder method for each property' do
+      City.find_by_state('Oregon').should_not be_nil
+    end
+
+    it 'should have a find all method for each property' do
+      City.find_all_by_state('Oregon').should_not be_nil
     end
 
   end


### PR DESCRIPTION
This commit allows you to call #find_by_attribute on an ActiveHash without having to explicitly call #all first.

This makes ActiveYaml behave the same way it would if you loaded the data using self.data
