### PR TITLE
support for find(:first, ...)

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -183,6 +183,8 @@ module ActiveHash
             nil
           when :all
             all
+          when :first
+            all(*args).first
           when Array
             id.map { |i| find(i) }
           else

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -316,6 +316,20 @@ describe ActiveHash, "Base" do
       end
     end
 
+    context "with :first" do
+      it "returns the first record" do
+        Country.find(:first).should == Country.new(:id => 1)
+      end
+
+      it "returns the first record that matches the search criteria" do
+        Country.find(:first, :conditions => {:id => 2}).should == Country.new(:id => 2)
+      end
+
+      it "returns nil if none matches the search criteria" do
+        Country.find(:first, :conditions => {:id => 3}).should == nil
+      end
+    end
+
     context "with 2 arguments" do
       it "returns the record with the given id and ignores the conditions" do
         Country.find(1, :conditions => "foo=bar").should == Country.new(:id => 1)


### PR DESCRIPTION
```
Model.find :first, :conditions => {:id => 1}
Model.find 1
```

Expected: both of these return the same
Actual: ActiveHash::RecordNotFound (Couldn't find User with ID=first).

This fixes it.

Note: I didn't break Rails 4 tests. They didn't work in the first place.