### PR TITLE
Adds ActiveHash#find_by functionality

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -157,6 +157,10 @@ module ActiveHash
         end
       end
 
+      def find_by(*args)
+        (where(*args) || []).first
+      end
+
       def count
         all.length
       end

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -288,13 +288,12 @@ describe ActiveHash, "Base" do
     end
 
     it "filters the records from a AR-like conditions hash" do
-      record = Country.find_by(name: 'US', language: 'English')
+      record = Country.find_by(:name => 'US', :language => 'English')
       record.id.should == 1
       record.name.should == 'US'
       record.language.should == 'English'
     end
   end
-
 
   describe ".count" do
     before do

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -247,6 +247,55 @@ describe ActiveHash, "Base" do
     end
   end
 
+  describe ".find_by" do
+    before do
+      Country.field :name
+      Country.field :language
+      Country.data = [
+        {:id => 1, :name => "US", :language => 'English'},
+        {:id => 2, :name => "Canada", :language => 'English'},
+        {:id => 3, :name => "Mexico", :language => 'Spanish'}
+      ]
+    end
+
+    it "raises ArgumentError if no conditions are provided" do
+      lambda{
+        Country.find_by
+      }.should raise_error(ArgumentError)
+    end
+
+    it "returns the first record when passed nil" do
+      Country.find_by(nil).should == Country.all.first
+    end
+
+    it "returns the first record as an inflated object" do
+      Country.find_by(:language => 'English').should be_kind_of(Country)
+    end
+
+    it "populates the data correctly" do
+      country = Country.find_by(:language => 'English')
+      country.id.should == 1
+      country.name.should == "US"
+    end
+
+    it "re-populates the records after data= is called" do
+      Country.data = [
+        {:id => 45, :name => "Canada"}
+      ]
+      country = Country.find_by(:name => 'Canada')
+      country.id.should == 45
+      country.name.should == "Canada"
+    end
+
+    it "filters the records from a AR-like conditions hash" do
+      record = Country.find_by(name: 'US', language: 'English')
+      record.id.should == 1
+      record.name.should == 'US'
+      record.language.should == 'English'
+    end
+  end
+
+
   describe ".count" do
     before do
       Country.data = [


### PR DESCRIPTION
Functionality similar to ActiveRecord::FinderMethods#find_by (https://github.com/rails/rails/blob/a8827cb9afdf122c003fbff1bfcc28bda2994d04/activerecord/lib/active_record/relation/finder_methods.rb#L82).

Includes updated specs.