### PR TITLE
add default value as lambda option in active hash

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -269,7 +269,8 @@ module ActiveHash
       def define_getter_method(field, default_value)
         unless has_instance_method?(field)
           define_method(field) do
-            attributes[field].nil? ? default_value : attributes[field]
+            
+            attributes[field].nil? ? (default_value.is_a?(Proc) ? (attributes[field]= default_value.call) : default_value) : attributes[field]
           end
         end
       end


### PR DESCRIPTION
Right now the way defaults work is that the value passed to default is initialized at class level.
This works fine for values but does not work for objects like hashes.

I have made it conditional to test if default assignment is a lambda, and calls / assigns field if it is. This allows you to declare a Hash as the default value, with that Hash being scoped in instance rather than class (or any object as default).

I haven't looked at this behavior in modules other than the ActiveHash one.
