### PR TITLE
Fix no method error on lib/active_hash/base.rb

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -35,7 +35,7 @@ module ActiveHash
         if Object.const_defined?(:ActiveModel)
           model_name.cache_key
         else
-          ActiveSupport::Inflector.tableize(self)
+          ActiveSupport::Inflector.tableize(self.name)
         end
       end
 


### PR DESCRIPTION
```
ActiveHash Base #cache_key should use the class's cache_key and id
Failure/Error: Country.first.cache_key.should == 'countries/1'
NoMethodError:
  undefined method `empty?' for Country:Class

ActiveHash Base #cache_key should use the record's updated_at if present
Failure/Error: Country.first.cache_key.should == "countries/1-#{timestamp.to_s(:number)}"
NoMethodError:
  undefined method `empty?' for Country:Class

ActiveHash Base #cache_key should use "new" instead of the id for a new record
Failure/Error: Country.new(:id => 1).cache_key.should == 'countries/new'
NoMethodError:
  undefined method `empty?' for Country:Class
```