### PR TITLE
exclude tests on rails 3.1 and 3.2 with ruby 1.8.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ matrix:
       env: SKIP_ACTIVE_RECORD=true
   exclude:
     - rvm: 1.8.7
+      gemfile: gemfiles/rails_3.1.gemfile
+    - rvm: 1.8.7
+      gemfile: gemfiles/rails_3.2.gemfile
+    - rvm: 1.8.7
       gemfile: gemfiles/rails_4.0.gemfile
     - rvm: 1.8.7
       gemfile: gemfiles/rails_4.1.gemfile


### PR DESCRIPTION
```
Gem::InstallError: i18n requires Ruby version >= 1.9.3.
Installing tzinfo 0.3.44
An error occurred while installing i18n (0.7.0), and Bundler cannot
continue.
Make sure that `gem install i18n -v '0.7.0'` succeeds before bundling.
```