### PR TITLE
Improvement `ActiveHash::Base#find_by`

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -157,13 +157,28 @@ module ActiveHash
       def where(options)
         return @records if options.nil?
         (@records || []).select do |record|
-          options.all? { |col, match| record[col] == match }
+          match_options?(record, options)
         end
       end
 
       def find_by(options)
-        where(options).first
+        return all.first if options.nil?
+        options.symbolize_keys!
+
+        if id = options.delete(:id)
+          candidates = Array(id).map { |i| find_by_id(id) }
+        end
+
+        (candidates || all).detect do |record|
+          match_options?(record, options)
+        end
       end
+
+      def match_options?(record, options)
+        options.all? { |col, match| record[col] == match }
+      end
+
+      private :match_options?
 
       def count
         all.length

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -292,6 +292,27 @@ describe ActiveHash, "Base" do
       record.id.should == 1
       record.name.should == 'US'
     end
+
+    it "finds the record with the specified id as a string" do
+      record = Country.find_by(:id => 1)
+      record.name.should == 'US'
+    end
+  end
+
+  describe ".match_options?" do
+    before do
+      Country.data = [
+        {:id => 1, :name => "US"}
+      ]
+    end
+
+    it "returns true when matched options" do
+      Country.send(:match_options?, Country.first, {:name => "US"}).should be_truthy
+    end
+
+    it "returns false when unmatched options" do
+      Country.send(:match_options?, Country.first, {:name => "Canada"}).should be_falsey
+    end
   end
 
   describe ".count" do

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -294,24 +294,16 @@ describe ActiveHash, "Base" do
     end
 
     it "finds the record with the specified id as a string" do
-      record = Country.find_by(:id => 1)
+      record = Country.find_by(:id => '1')
       record.name.should == 'US'
     end
-  end
 
-  describe ".match_options?" do
-    before do
-      Country.data = [
-        {:id => 1, :name => "US"}
-      ]
+    it "returns the record that matches options" do
+      expect(Country.find_by(:name => "US").id).to eq(1)
     end
 
-    it "returns true when matched options" do
-      Country.send(:match_options?, Country.first, {:name => "US"}).should be_truthy
-    end
-
-    it "returns false when unmatched options" do
-      Country.send(:match_options?, Country.first, {:name => "Canada"}).should be_falsey
+    it "returns nil when not matched in candidates" do
+      expect(Country.find_by(:name => "UK")).to be_nil
     end
   end
 


### PR DESCRIPTION
Use `find_by_id` to search by `id` and omitted unnecessary loop. (`find` is using `find_by_id`)
Has become possible to search by id of string.

```
# Country.data = [{:id => 1, :name => "US"}]
Country.find("1") #=> return record
Country.find_by(id: "1") #=> before returns nil, after returns record
```