### PR TITLE
yield block on initilize

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -405,6 +405,7 @@ module ActiveHash
       attributes.dup.each do |key, value|
         send "#{key}=", value
       end
+      yield self if block_given?
     end
 
     def attributes

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -15,6 +15,25 @@ describe ActiveHash, "Base" do
     expect { Country.transaction }.to raise_error(LocalJumpError)
   end
 
+  describe ".new" do
+    it "yields a block" do
+      expect { |b| Country.new(&b) }.to yield_with_args(Country)
+    end
+
+    context "initializing with a block" do
+      subject do
+        Country.fields :name
+        Country.new do |country|
+          country.name = 'Germany'
+        end
+      end
+
+      it "sets assigns the fields" do
+        expect(subject.name).to eq('Germany')
+      end
+    end
+  end
+
   describe ".fields" do
     before do
       Country.fields :name, :iso_name


### PR DESCRIPTION
[ActiveRecord#initialize](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/core.rb#L307) yields a block on initialize. It would be handy for ActiveHash to do the same, don't you think?