### PR TITLE
⚠️ Ruby warnings

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -317,7 +317,7 @@ module ActiveHash
         unless has_singleton_method?(method_name)
           the_meta_class.instance_eval do
             define_method(method_name) do |*args|
-              options = args.extract_options!
+              args.extract_options!
               identifier = args[0]
               all.detect { |record| record.send(field_name) == identifier }
             end
@@ -333,7 +333,7 @@ module ActiveHash
           the_meta_class.instance_eval do
             unless singleton_methods.include?(method_name)
               define_method(method_name) do |*args|
-                options = args.extract_options!
+                args.extract_options!
                 identifier = args[0]
                 all.select { |record| record.send(field_name) == identifier }
               end

--- a/lib/active_yaml/aliases.rb
+++ b/lib/active_yaml/aliases.rb
@@ -13,14 +13,14 @@ module ActiveYaml
 
       def raw_data
         YAML.load_file(full_path).reject do |k, v|
-          v.kind_of? Hash and k.match /^\//i
+          v.kind_of? Hash and k.match(/^\//i)
         end
       end
 
     end
 
     def initialize(attributes={})
-      super unless attributes.keys.index { |k| k.to_s.match /^\//i }
+      super unless attributes.keys.index { |k| k.to_s.match(/^\//i) }
     end
   end
 


### PR DESCRIPTION
This patch eliminates two types of Ruby warnings: unused local variable and Regexp literal ambiguity.