### PR TITLE
Support read_attribute method

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -422,6 +422,7 @@ module ActiveHash
     def _read_attribute(key)
       attributes[key]
     end
+    alias :read_attribute :_read_attribute
 
     def []=(key, val)
       attributes[key] = val

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -422,7 +422,7 @@ module ActiveHash
     def _read_attribute(key)
       attributes[key]
     end
-    alias :read_attribute :_read_attribute
+    alias_method :read_attribute, :_read_attribute
 
     def []=(key, val)
       attributes[key] = val

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -642,6 +642,12 @@ describe ActiveHash, "Base" do
       country._read_attribute(:foo).should == :bar
     end
 
+    it "works with read_attribute" do
+      Country.field :foo
+      country = Country.new(:foo => :bar)
+      country.read_attribute(:foo).should == :bar
+    end
+
     it "works with #[]=" do
       Country.field :foo
       country = Country.new


### PR DESCRIPTION
Some gems([like a enumerize](https://github.com/brainspec/enumerize/blob/master/lib/enumerize/attribute.rb#L87-L89)) expects #read_attribute method.