### PR TITLE
add rails 42 and ruby 22 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,28 @@
 sudo: false
 rvm:
-  - "1.8.7"
+  #- "1.8.7" # only test rails < 4.0 (deprecated, reduced coverage)
   - "1.9.3"
-  - "2.1.2"
+  - "2.1.5"
+  - "2.2.4"
   - jruby
   #- rbx-2.2.3
 gemfile:
-  - gemfiles/rails_2.3.gemfile
+  #- gemfiles/rails_2.3.gemfile # only test for ruby < 2.0
   - gemfiles/rails_3.0.gemfile
   - gemfiles/rails_3.1.gemfile
   - gemfiles/rails_3.2.gemfile
   - gemfiles/rails_4.0.gemfile
   - gemfiles/rails_4.1.gemfile
+  - gemfiles/rails_4.2.gemfile
 matrix:
   include:
-    - rvm: 2.2.3
+    - rvm: 1.8.7
+      gemfile: gemfiles/rails_2.3.gemfile
+    - rvm: 1.8.7
+      gemfile: gemfiles/rails_3.2.gemfile
+    - rvm: 1.9.3
+      gemfile: gemfiles/rails_2.3.gemfile
+    - rvm: 2.2.4
       gemfile: gemfiles/rails_4.0.no-active-record.gemfile
       env: SKIP_ACTIVE_RECORD=true
-  exclude:
-    - rvm: 1.8.7
-      gemfile: gemfiles/rails_4.0.gemfile
-    - rvm: 1.8.7
-      gemfile: gemfiles/rails_4.1.gemfile
-    - rvm: 2.1.2
-      gemfile: gemfiles/rails_2.3.gemfile
-    - rvm: rbx-2.2.3
-      gemfile: gemfiles/rails_2.3.gemfile
-    - rvm: jruby
-      gemfile: gemfiles/rails_2.3.gemfile
 script: "bundle exec rake spec"

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'rspec', '~> 2.2.0'
 gem 'wwtd'
 gem 'rake'
 gem 'json'
+gem 'test-unit'
 
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.6'

--- a/gemfiles/rails_3.0.gemfile
+++ b/gemfiles/rails_3.0.gemfile
@@ -5,6 +5,7 @@ gem 'rspec', '~> 2.2.0'
 gem 'wwtd'
 gem 'rake'
 gem 'json'
+gem 'test-unit'
 
 platform :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.6'

--- a/gemfiles/rails_3.1.gemfile
+++ b/gemfiles/rails_3.1.gemfile
@@ -6,6 +6,7 @@ gem 'wwtd'
 gem 'rake'
 gem 'json'
 gem 'i18n', '~> 0.6.11'
+gem 'test-unit'
 
 platform :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.6'

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -5,6 +5,7 @@ gem 'rspec', '~> 2.2.0'
 gem 'wwtd'
 gem 'rake'
 gem 'json'
+gem 'test-unit'
 
 platform :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.6'

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -1,11 +1,10 @@
 source 'http://rubygems.org/'
 
-gem 'activerecord', '~> 3.2.0'
+gem 'activerecord', '~> 4.2.0'
 gem 'rspec', '~> 2.2.0'
 gem 'wwtd'
 gem 'rake'
 gem 'json'
-gem 'i18n', '~> 0.6.11'
 gem 'test-unit'
 
 platform :jruby do


### PR DESCRIPTION
more recent versions of ruby no longer support test-unit out of the box
So this gem has been explicitly added

since ruby 1.8.7 is deprecated, add just a few older entries to matrix
since rails 2.3 is old, just test on older ruby versions

removing those versions from the complete matrix, to simplify excludes

add latest ruby 2.2.5 and rails 4.2 to the mix