### PR TITLE
gemfile for ruby 1.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,13 @@ gemspec
 gem 'rspec', '~> 2.2.0'
 gem 'wwtd'
 gem 'rake'
-gem 'json'
 gem 'test-unit'
+
+if RUBY_VERSION < '2.0.0'
+  gem 'json', '< 2.0.0'
+else
+  gem 'json'
+end
 
 platforms :jruby do
   gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.6'


### PR DESCRIPTION
Older versions of ruby need older version of json

1. I need to figure out the build system and generating the Gemfiles
2. @zilkey 1.9.3 and 2.0.0 are not supported. Do you want to still support them?