### PR TITLE
Give objects without instance variables to users

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -150,7 +150,7 @@ module ActiveHash
         if options.has_key?(:conditions)
           where(options[:conditions])
         else
-          @records || []
+          @records && @records.clone || []
         end
       end
 
@@ -161,15 +161,18 @@ module ActiveHash
         if (ids = (options.delete(:id) || options.delete("id")))
           candidates = Array.wrap(ids).map { |id| find_by_id(id) }
         end
-        return candidates if options.blank?
+        return candidates.clone if options.blank?
 
         (candidates || @records || []).select do |record|
           match_options?(record, options)
+        end.map do |record|
+          record.clone
         end
       end
 
       def find_by(options)
-        where(options).first
+        result = where(options).first
+        result && result.clone || nil
       end
 
       def match_options?(record, options)

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -203,6 +203,15 @@ describe ActiveHash, "Base" do
       record.first.id.should == 1
       record.first.name.should == 'US'
     end
+
+    it "returns objects without instance variables" do
+      record = Country.all(:conditions => {:name => 'US'}).first
+      record.instance_variable_set(:@temporary, "value")
+      record.instance_variables.should include(:@temporary)
+
+      new_instance = Country.all(:conditions => {:name => 'US'}).first
+      new_instance.instance_variables.should_not include(:@temporary)
+    end
   end
 
   describe ".where" do
@@ -276,6 +285,15 @@ describe ActiveHash, "Base" do
     it "filters records for multiple values" do
       expect(Country.where(:name => %w(US Canada)).map(&:name)).to match_array(%w(US Canada))
     end
+
+    it "returns objects without instance variables" do
+      record = Country.where(:name => 'US').first
+      record.instance_variable_set(:@temporary, "value")
+      record.instance_variables.should include(:@temporary)
+
+      new_instance = Country.where(:name => 'US').first
+      new_instance.instance_variables.should_not include(:@temporary)
+    end
   end
 
   describe ".find_by" do
@@ -335,6 +353,15 @@ describe ActiveHash, "Base" do
 
     it "returns nil when not matched in candidates" do
       expect(Country.find_by(:name => "UK")).to be_nil
+    end
+
+    it "returns objects without instance variables" do
+      record = Country.find_by(:id => '1')
+      record.instance_variable_set(:@temporary, "value")
+      record.instance_variables.should include(:@temporary)
+
+      new_instance = Country.find_by(:id => '1')
+      new_instance.instance_variables.should_not include(:@temporary)
     end
   end
 


### PR DESCRIPTION
Separate the original state of the records in an ActiveHash sub-class
from the records that are being passed around in the rest of the
application
