### PR TITLE
Fix ActiveYaml::Aliases when using multiple files

### DIFF
--- a/lib/active_yaml/aliases.rb
+++ b/lib/active_yaml/aliases.rb
@@ -12,7 +12,7 @@ module ActiveYaml
       end
 
       def raw_data
-        YAML.load_file(full_path).reject do |k, v|
+        super.reject do |k, v|
           v.kind_of? Hash and k.match(/^\//i)
         end
       end

--- a/spec/active_yaml/aliases_spec.rb
+++ b/spec/active_yaml/aliases_spec.rb
@@ -63,6 +63,29 @@ describe ActiveYaml::Aliases do
     end
   end
 
+  describe 'Loading multiple files' do
+    let(:model) { MultipleFiles }
+    let(:coke) { model.where(name: 'Coke').first }
+    let(:schweppes) { model.where(name: 'Schweppes').first }
+
+    before do
+      class MultipleFiles < ActiveYaml::Base
+        include ActiveYaml::Aliases
+        use_multiple_files
+        set_filenames 'array_products', 'array_products_2'
+      end
+    end
+
+    after do
+      Object.send :remove_const, :MultipleFiles
+    end
+
+    it 'returns correct data from both files' do
+      expect(coke.flavor).to eq 'sweet'
+      expect(schweppes.flavor).to eq 'bitter'
+    end
+  end
+
   # As Ruby < 1.9.3 uses the Sych YAML engine
   # it includes a bug whereby an aliased value is treated as a string
   # we just skip over this issue because it's a Ruby bug

--- a/spec/fixtures/array_products_2.yml
+++ b/spec/fixtures/array_products_2.yml
@@ -1,0 +1,10 @@
+- /aliases:
+  soda_flavor: &soda_flavor
+    bitter
+  soda_price: &soda_price
+    1.5
+
+- id: 5
+  name: Schweppes
+  flavor: *soda_flavor
+  price: *soda_price


### PR DESCRIPTION
The current implementation of `ActiveYaml::Aliases` does not allow to use multiples files. This patch fixes it.