### PR TITLE
remove warning

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -150,7 +150,7 @@ module ActiveHash
         if options.has_key?(:conditions)
           where(options[:conditions])
         else
-          @records || []
+          @records ||= []
         end
       end
 


### PR DESCRIPTION
saw this when running tests ...

lib/active_hash/base.rb:155: warning: instance variable @records not initialized

@kbrock 