### PR TITLE
Add support for array values in where conditions

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -174,10 +174,8 @@ module ActiveHash
 
       def match_options?(record, options)
         options.all? do |col, match|
-          if match.kind_of?(Array)
-            match.include?(record[col])
-          else
-            record[col] == match
+          [match].flatten.any? do |value|
+            [record[col]].flatten.include?(value)
           end
         end
       end

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -206,13 +206,15 @@ describe ActiveHash, "Base" do
   end
 
   describe ".where" do
+    let(:country_without_name) { Country.find(4) }
     before do
       Country.field :name
       Country.field :language
       Country.data = [
         {:id => 1, :name => "US", :language => 'English'},
         {:id => 2, :name => "Canada", :language => 'English'},
-        {:id => 3, :name => "Mexico", :language => 'Spanish'}
+        {:id => 3, :name => "Mexico", :language => 'Spanish'},
+        {:id => 4, :name => nil, :language => 'None'}
       ]
     end
 
@@ -275,6 +277,10 @@ describe ActiveHash, "Base" do
 
     it "filters records for multiple values" do
       expect(Country.where(:name => %w(US Canada)).map(&:name)).to match_array(%w(US Canada))
+    end
+
+    it "matches nil attributes correctly" do
+      expect(Country.where(name: nil)).to match_array [country_without_name]
     end
   end
 


### PR DESCRIPTION
This adds the possibility to have arrays as values in data.
So an attribute can have a value of `[1,2,3]` for example and you’ll be able to search for it by doing `.where(attribute: 3)` or `.where(attribute: [1,3])`.
Other values are still handled correctly, in particular `nil`. So if you have data with a `nil` attribute, it will correctly returns the records too: `.where(attribute: nil)`.