### PR TITLE
Don't generate instance accessors for class attributes

### DIFF
--- a/lib/active_file/base.rb
+++ b/lib/active_file/base.rb
@@ -4,7 +4,7 @@ module ActiveFile
     extend ActiveFile::MultipleFiles
 
     if respond_to?(:class_attribute)
-      class_attribute :filename, :root_path, :data_loaded
+      class_attribute :filename, :root_path, :data_loaded, instance_reader: false, instance_writer: false
     else
       class_inheritable_accessor :filename, :root_path, :data_loaded
     end

--- a/lib/active_file/multiple_files.rb
+++ b/lib/active_file/multiple_files.rb
@@ -6,7 +6,7 @@ module ActiveFile
 
     def use_multiple_files
       if respond_to?(:class_attribute)
-        class_attribute :filenames
+        class_attribute :filenames, instance_reader: false, instance_writer: false
       else
         class_inheritable_accessor :filenames
       end


### PR DESCRIPTION
I have a model with an attribute called `filename`, which was confusingly always returning nil. These changes ensure `filename`, `root_path`, `data_loaded`, and `filenames`, which are class-level concerns, don't conflict with model use.