### PR TITLE
Rescue LoadError

### DIFF
--- a/lib/associations/associations.rb
+++ b/lib/associations/associations.rb
@@ -8,7 +8,14 @@ module ActiveHash
         options = our_args.extract_options!
         name = our_args.shift
         options = {:class_name => name.to_s.camelize }.merge(options)
-        klass = options[:class_name].constantize rescue nil
+        klass =
+          begin
+            options[:class_name].constantize
+          rescue
+            nil
+          rescue LoadError
+            nil
+          end
         if klass && klass < ActiveHash::Base
           belongs_to_active_hash(name, options)
         else

--- a/spec/associations/active_record_extensions_spec.rb
+++ b/spec/associations/active_record_extensions_spec.rb
@@ -177,6 +177,12 @@ unless SKIP_ACTIVE_RECORD
           school = School.create :city_id => city.id
           school.city.should == city
         end
+
+        it "returns nil when the belongs_to association class can't be autoloaded" do
+          # Simulate autoloader
+          allow_any_instance_of(String).to receive(:constantize).and_raise(LoadError, "Unable to autoload constant NonExistent")
+          School.belongs_to :city, {class_name: 'NonExistent'}
+        end
       end
 
       describe "#belongs_to_active_hash" do


### PR DESCRIPTION
A bare rescue won't recover from a load error.  Options parsing
sometimes misses class_name here, which can cause LoadError when the
guess for class_name is wrong.

When this happens, we would rather assume that we aren't dealing with
an ActiveHash rather than crashing