### PR TITLE
Add rake version dependency

### DIFF
--- a/gemfiles/rails_3.0.gemfile
+++ b/gemfiles/rails_3.0.gemfile
@@ -3,7 +3,7 @@ source 'http://rubygems.org/'
 gem 'activerecord', '~> 3.0.0'
 gem 'rspec', '~> 2.2.0'
 gem 'wwtd'
-gem 'rake'
+gem 'rake', '~> 10.0'
 gem 'test-unit'
 
 if RUBY_VERSION < "2"

--- a/gemfiles/rails_3.1.gemfile
+++ b/gemfiles/rails_3.1.gemfile
@@ -3,7 +3,7 @@ source 'http://rubygems.org/'
 gem 'activerecord', '~> 3.1.0'
 gem 'rspec', '~> 2.2.0'
 gem 'wwtd'
-gem 'rake'
+gem 'rake', '~> 10.0'
 gem 'i18n', '~> 0.6.11'
 gem 'test-unit'
 

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -3,7 +3,7 @@ source 'http://rubygems.org/'
 gem 'activerecord', '~> 4.0.0'
 gem 'rspec', '~> 2.2.0'
 gem 'wwtd'
-gem 'rake'
+gem 'rake', '~> 10.0'
 gem 'i18n'
 gem 'test-unit'
 

--- a/gemfiles/rails_4.0.no-active-record.gemfile
+++ b/gemfiles/rails_4.0.no-active-record.gemfile
@@ -2,7 +2,7 @@ source 'http://rubygems.org/'
 
 gem 'rspec', '~> 2.2.0'
 gem 'wwtd'
-gem 'rake'
+gem 'rake', '~> 10.0'
 gem 'i18n'
 gem 'test-unit'
 

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -3,7 +3,7 @@ source 'http://rubygems.org/'
 gem 'activerecord', '~> 4.1.0'
 gem 'rspec', '~> 2.2.0'
 gem 'wwtd'
-gem 'rake'
+gem 'rake', '~> 10.0'
 gem 'json'
 gem 'test-unit'
 

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -3,7 +3,7 @@ source 'http://rubygems.org/'
 gem 'activerecord', '~> 4.2.0'
 gem 'rspec', '~> 2.2.0'
 gem 'wwtd'
-gem 'rake'
+gem 'rake', '~> 10.0'
 gem 'json'
 gem 'test-unit'
 

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -4,7 +4,7 @@ gem 'activerecord', :git=>'https://github.com/rails/rails.git'
 gem 'activesupport', :git=>'https://github.com/rails/rails.git'
 gem 'rspec', '~> 2.2.0'
 gem 'wwtd'
-gem 'rake'
+gem 'rake', '~> 10.0'
 gem 'json'
 
 platform :jruby do


### PR DESCRIPTION
Hi.
 `last_comment` method (called from rspec 2.99) has removed from Rake( >= 11.0) https://github.com/ruby/rake/commit/e76242ce7ef94568399a50b69bda4b723dab7c75
So this repository fails to build on Travis CI.
This PR avoids that problem 😄 