### PR TITLE
Fix a bug that returns nil instead of empty array from 575fe9d

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -158,7 +158,8 @@ module ActiveHash
         return @records if options.blank?
 
         # use index if searching by id
-        if (ids = (options.delete(:id) || options.delete("id")))
+        if options.key?(:id) || options.key?("id")
+          ids = (options.delete(:id) || options.delete("id"))
           candidates = Array.wrap(ids).map { |id| find_by_id(id) }
         end
         return candidates if options.blank?

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -269,6 +269,16 @@ describe ActiveHash, "Base" do
       end.should raise_error(ActiveHash::IdError)
     end
 
+    it "returns a record for specified id" do
+      record = Country.where(id: 1)
+      record.first.id.should == 1
+      record.first.name.should == 'US'
+    end
+
+    it "returns empty array" do
+      expect(Country.where(id: nil)).to eq []
+    end
+
     it "returns multiple records for multiple ids" do
       expect(Country.where(:id => %w(1 2)).map(&:id)).to match_array([1,2])
     end


### PR DESCRIPTION
I'm sorry, I released v1.5.0 several days ago, but It has breaking bug.
I fixed that issue.