### PR TITLE
Fix find_by when passed an invalid id

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -160,7 +160,7 @@ module ActiveHash
         # use index if searching by id
         if options.key?(:id) || options.key?("id")
           ids = (options.delete(:id) || options.delete("id"))
-          candidates = Array.wrap(ids).map { |id| find_by_id(id) }
+          candidates = Array.wrap(ids).map { |id| find_by_id(id) }.compact
         end
         return candidates if options.blank?
 

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -346,6 +346,10 @@ describe ActiveHash, "Base" do
     it "returns nil when not matched in candidates" do
       expect(Country.find_by(:name => "UK")).to be_nil
     end
+
+    it "returns nil when passed a wrong id" do
+      expect(Country.find_by(:id => 4)).to be_nil
+    end
   end
 
   describe ".find_by!" do
@@ -367,6 +371,15 @@ describe ActiveHash, "Base" do
     context 'when data not found' do
       let(:word) { 'UK' }
       it { expect{ subject }.to raise_error ActiveHash::RecordNotFound }
+      it "raises 'RecordNotFound' when passed a wrong id" do
+        expect { Country.find_by!(id: 2) }.
+          to raise_error ActiveHash::RecordNotFound
+      end
+
+      it "raises 'RecordNotFound' when passed wrong id and options" do
+        expect { Country.find_by!(id: 2, name: "FR") }.
+          to raise_error ActiveHash::RecordNotFound
+      end
     end
   end
 


### PR DESCRIPTION
```rb
 # Assuming there is no country with id 2.
Country.find_by!(id: 2, name: "UK")
```

Before:
> Exception: NoMethodError: undefined method \`[]' for nil:NilClass
> (...) active_hash/base.rb:185:in `block in match_options?'

After:
> ActiveHash::RecordNotFound: Couldn't find Country