### PR TITLE
Support symbol values in where and find_by

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -180,14 +180,20 @@ module ActiveHash
       def match_options?(record, options)
         options.all? do |col, match|
           if match.kind_of?(Array)
-            match.map(&:to_s).include?(record[col].to_s)
+            match.any? { |v| normalize(v) == normalize(record[col]) }
           else
-            record[col].to_s == match.to_s
+            normalize(record[col]) == normalize(match)
           end
         end
       end
 
       private :match_options?
+
+      def normalize(v)
+        v.respond_to?(:to_sym) ? v.to_sym : v
+      end
+
+      private :normalize
 
       def count
         all.length

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -180,9 +180,9 @@ module ActiveHash
       def match_options?(record, options)
         options.all? do |col, match|
           if match.kind_of?(Array)
-            match.include?(record[col])
+            match.map(&:to_s).include?(record[col].to_s)
           else
-            record[col] == match
+            record[col].to_s == match.to_s
           end
         end
       end

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -286,6 +286,10 @@ describe ActiveHash, "Base" do
     it "filters records for multiple values" do
       expect(Country.where(:name => %w(US Canada)).map(&:name)).to match_array(%w(US Canada))
     end
+
+    it "filters records for multiple symbol values" do
+      expect(Country.where(:name => [:US, :Canada]).map(&:name)).to match_array(%w(US Canada))
+    end
   end
 
   describe ".find_by" do
@@ -341,6 +345,10 @@ describe ActiveHash, "Base" do
 
     it "returns the record that matches options" do
       expect(Country.find_by(:name => "US").id).to eq(1)
+    end
+
+    it "returns the record that matches options with symbol value" do
+      expect(Country.find_by(:name => :US).id).to eq(1)
     end
 
     it "returns nil when not matched in candidates" do


### PR DESCRIPTION
## WHAT
This patch introduces symbol support to `where` and `find_by`.

## WHY
`ActiveRecord` accepts symbol values in `where` and `find_by`.
I want to use `ActiveHash` as an alternative of `ActiveRecord`, so I want symbol support.

## Example
### Data

```yml
# colors.yml
- id: 1
  color: red
- id: 2
  color: blue
```

```ruby
# app/models/color.rb
class Color < ActiveYaml::Base
end
```


### Before

```ruby
[1] pry(main)> Color.where(color: ["red", "blue"])
=> [#<Color:0x007fc79a0e1898 @attributes={:color=>"red", :id=>1}>,
 #<Color:0x007fc79a0e03a8 @attributes={:color=>"blue", :id=>2}>]
[2] pry(main)> Color.where(color: [:red, :blue])
=> []
```

### After

```ruby
[1] pry(main)> Color.where(color: ["red", "blue"])
=> [#<Color:0x007fc79a0e1898 @attributes={:color=>"red", :id=>1}>,
 #<Color:0x007fc79a0e03a8 @attributes={:color=>"blue", :id=>2}>]
[2] pry(main)> Color.where(color: [:red, :blue])
=> [#<Color:0x007fc79a0e1898 @attributes={:color=>"red", :id=>1}>,
 #<Color:0x007fc79a0e03a8 @attributes={:color=>"blue", :id=>2}>]
```
