### PR TITLE
Refactor association methods + fix issue with `#find_by_id` 

### DIFF
--- a/spec/associations/associations_spec.rb
+++ b/spec/associations/associations_spec.rb
@@ -32,7 +32,7 @@ describe ActiveHash::Base, "associations" do
           @excluded_author = Author.create :city_id => 2
         end
 
-        it "find the correct records" do
+        it "finds the correct records" do
           City.has_many :authors
           city = City.create :id => 1
           city.authors.should == [@included_author_1, @included_author_2]


### PR DESCRIPTION
## What's this PR do?

It changes the use of  `#find_by_id` in favor of `#find_by`. It also refactors some portion of the code related to the associations macros (`belongs_to`, `has_one`, `has_many`).

## TODOs

- [x] Create an abstract method to fetch associations;
- [x] Use `#find_by` rather than `#find_by_*` when fetching single associations;
- [x] Pass specs.

## Background context

Recently we went through a weird situation at [Beauty Date](https://beautydate.com) while running our seeds file. It turned out that a model based on `ActiveHash` was not retrieving a `belongs_to` association for calling the underlying `#find_by_id` on the related model and returning `nil`.

I did a little debug and figured out that, unlike the `#find_by_*`, calling the `#find_by` method was actually working as expected. I don't know yet the reason for this bug to be happening apparently 
 only when executing the seed task. Maybe it's something related to the seed context and the metaprogamming applied while defining those dynamic finders. I sure will need to make a deeper debug on it.

For now this fork has fixed the issue. Anyway, I think that avoiding unnecessary is a good practice (safer, faster etc).

## Manual test

```ruby
# belongs_to
City.belongs_to :country
City.first.country

# has_many
Country.has_many :cities
Country.first.cities

# has_one
Country.has_one :mayor
Country.first.mayor
```