### PR TITLE
Fix to be able to use enum accessor constant with same name as top-level constant

### DIFF
--- a/lib/enum/enum.rb
+++ b/lib/enum/enum.rb
@@ -23,7 +23,7 @@ module ActiveHash
         if @enum_accessors.present?
           @records.each do |record|
             constant = constant_for(record, @enum_accessors)
-            remove_const(constant) if const_defined?(constant)
+            remove_const(constant) if const_defined?(constant, false)
           end
         end
         super
@@ -33,10 +33,10 @@ module ActiveHash
         constant = constant_for(record, @enum_accessors)
         return nil if constant.blank?
 
-        unless const_defined?(constant)
+        unless const_defined?(constant, false)
           const_set(constant, record)
         else
-          raise DuplicateEnumAccessor, "#{constant} already defined for #{self.class}" unless const_get(constant) == record
+          raise DuplicateEnumAccessor, "#{constant} already defined for #{self.class}" unless const_get(constant, false) == record
         end
       end
 

--- a/spec/enum/enum_spec.rb
+++ b/spec/enum/enum_spec.rb
@@ -50,6 +50,20 @@ describe ActiveHash::Base, "enum" do
       end.should raise_error(ActiveHash::Enum::DuplicateEnumAccessor)
     end
 
+    it "can use enum accessor constant with same name as top-level constant" do
+      expect do
+        Class.new(ActiveHash::Base) do
+          include ActiveHash::Enum
+          self.data = [
+            {:type => 'JSON'},
+            {:type => 'YAML'},
+            {:type => 'XML'}
+          ]
+          enum_accessor :type
+        end
+      end.not_to raise_error
+    end
+
     it "removes non-word characters from values before setting constants" do
       Movie = Class.new(ActiveHash::Base) do
         include ActiveHash::Enum


### PR DESCRIPTION
## Overview
I fixed to be able to use enum accessor constant with same name as top-level constant such as `JSON`.

## Before & After Behavior
### Before (v2.0.0)
```
irb(main):001:0> class FooFormat < ActiveHash::Base
irb(main):002:1>   include ActiveHash::Enum
irb(main):003:1>   self.data = [
irb(main):004:2*     { type: 'JSON'},
irb(main):005:2*     { type: 'YAML'},
irb(main):006:2*     { type: 'XML'}
irb(main):007:2>   ]
irb(main):008:1>   enum_accessor :type
irb(main):009:1> end
Traceback (most recent call last):
       16: from /home/yuji_developer/.rbenv/versions/2.5.0/lib/ruby/site_ruby/2.5.0/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
       15: from /home/yuji_developer/.rbenv/versions/2.5.0/lib/ruby/site_ruby/2.5.0/bundler/cli.rb:27:in `dispatch'
       14: from /home/yuji_developer/.rbenv/versions/2.5.0/lib/ruby/site_ruby/2.5.0/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
       13: from /home/yuji_developer/.rbenv/versions/2.5.0/lib/ruby/site_ruby/2.5.0/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
       12: from /home/yuji_developer/.rbenv/versions/2.5.0/lib/ruby/site_ruby/2.5.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
       11: from /home/yuji_developer/.rbenv/versions/2.5.0/lib/ruby/site_ruby/2.5.0/bundler/cli.rb:455:in `console'
       10: from /home/yuji_developer/.rbenv/versions/2.5.0/lib/ruby/site_ruby/2.5.0/bundler/cli/console.rb:19:in `run'
        9: from (irb):1
        8: from (irb):8:in `<class:FooFormat>'
        7: from /home/yuji_developer/oss/active_hash/lib/enum/enum.rb:14:in `enum_accessor'
        6: from /home/yuji_developer/oss/active_hash/lib/active_hash/base.rb:402:in `reload'
        5: from /home/yuji_developer/oss/active_hash/lib/active_hash/base.rb:79:in `data='
        4: from /home/yuji_developer/oss/active_hash/lib/active_hash/base.rb:79:in `each'
        3: from /home/yuji_developer/oss/active_hash/lib/active_hash/base.rb:80:in `block in data='
        2: from /home/yuji_developer/oss/active_hash/lib/enum/enum.rb:19:in `insert'
        1: from /home/yuji_developer/oss/active_hash/lib/enum/enum.rb:39:in `set_constant'
ActiveHash::Enum::DuplicateEnumAccessor (JSON already defined for Class)
irb(main):010:0>
```

### After
```
irb(main):001:0> class FooFormat < ActiveHash::Base
irb(main):002:1>   include ActiveHash::Enum
irb(main):003:1>   self.data = [
irb(main):004:2*     { type: 'JSON'},
irb(main):005:2*     { type: 'YAML'},
irb(main):006:2*     { type: 'XML'}
irb(main):007:2>   ]
irb(main):008:1>   enum_accessor :type
irb(main):009:1> end
=> false
irb(main):010:0> FooFormat::JSON
=> #<FooFormat:0x00007fffdc6c0618 @attributes={:type=>"JSON", :id=>1}>
irb(main):011:0> FooFormat.constants
=> [:YAML, :JSON, :XML, :DuplicateEnumAccessor, :Methods, :ClassMethods]
irb(main):012:0>
```