### PR TITLE
Delete codes for old ActiveSupport

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,4 +21,4 @@ platforms :ruby do
   gem 'sqlite3'
 end
 
-gem 'activerecord', '>= 2.2.2'
+gem 'activerecord', '>= 5.0.0'

--- a/lib/active_file/base.rb
+++ b/lib/active_file/base.rb
@@ -3,11 +3,7 @@ module ActiveFile
   class Base < ActiveHash::Base
     extend ActiveFile::MultipleFiles
 
-    if respond_to?(:class_attribute)
-      class_attribute :filename, :root_path, :data_loaded, instance_reader: false, instance_writer: false
-    else
-      class_inheritable_accessor :filename, :root_path, :data_loaded
-    end
+    class_attribute :filename, :root_path, :data_loaded, instance_reader: false, instance_writer: false
 
     class << self
 

--- a/lib/active_file/multiple_files.rb
+++ b/lib/active_file/multiple_files.rb
@@ -5,11 +5,7 @@ module ActiveFile
     end
 
     def use_multiple_files
-      if respond_to?(:class_attribute)
-        class_attribute :filenames, instance_reader: false, instance_writer: false
-      else
-        class_inheritable_accessor :filenames
-      end
+      class_attribute :filenames, instance_reader: false, instance_writer: false
 
       def self.set_filenames(*filenames)
         self.filenames = filenames

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -14,11 +14,7 @@ module ActiveHash
 
   class Base
 
-    if respond_to?(:class_attribute)
-      class_attribute :_data, :dirty, :default_attributes
-    else
-      class_inheritable_accessor :_data, :dirty, :default_attributes
-    end
+    class_attribute :_data, :dirty, :default_attributes
 
     if Object.const_defined?(:ActiveModel)
       extend ActiveModel::Naming


### PR DESCRIPTION
`Class#class_inheritable_accessor` has been deleted at ActiveSupport v4.0