### PR TITLE
Add ::scope method (inspired by ActiveRecord)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,14 @@ Country.find_all_by_name "foo"                # => returns an array of the objec
 Country.find_by_id_and_name 1, "Germany"      # => returns the first object matching that id and name
 Country.find_all_by_id_and_name 1, "Germany"  # => returns an array of objects matching that name and id
 ```
+
+Furthermore, it allows to create custom scope query methods, similar to how it's possible with ActiveRecord:
+
+```ruby
+Country.scope :english, -> { where(language: 'English') } # Creates a class method Country.english performing the given query
+Country.scope :with_language, ->(language) { where(language: language) } # Creates a class method Country.with_language(language) performing the given query
+```
+
 ## Instance Methods
 
 ActiveHash objects implement enough of the ActiveRecord api to satisfy most common needs.  For example:

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -469,8 +469,10 @@ module ActiveHash
       def scope(name, body)
         raise ArgumentError, 'body needs to be callable' unless body.respond_to?(:call)
         
-        singleton_class.define_method(name) do |*args|
-          instance_exec(*args, &body)
+        the_meta_class.instance_eval do
+          define_method(name) do |*args|
+            instance_exec(*args, &body)
+          end
         end
       end
 

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -465,6 +465,12 @@ module ActiveHash
       end
 
       private :mark_clean
+      
+      def scope(name, body)
+        singleton_class.define_method(name) do |*args|
+          instance_exec(*args, &body)
+        end
+      end
 
     end
 

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -467,6 +467,8 @@ module ActiveHash
       private :mark_clean
       
       def scope(name, body)
+        raise ArgumentError, 'body needs to be callable' unless body.respond_to?(:call)
+        
         singleton_class.define_method(name) do |*args|
           instance_exec(*args, &body)
         end

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -1320,5 +1320,61 @@ describe ActiveHash, "Base" do
     end
 
   end
+  
+  describe '.scope' do
+    context 'for query without argument' do      
+      before do
+        Country.field :name
+        Country.field :language
+        Country.data = [
+          {:id => 1, :name => "US", :language => 'English'},
+          {:id => 2, :name => "Canada", :language => 'English'},
+          {:id => 3, :name => "Mexico", :language => 'Spanish'}
+        ]
+        Country.scope :english_language, -> { where(language: 'English') }
+      end
+      
+      it 'should define a scope method' do
+        expect(Country.respond_to?(:english_language)).to be_truthy
+      end
+      
+      it 'should return the query used to define the scope' do
+        expect(Country.english_language).to eq Country.where(language: 'English')
+      end
+      
+      it 'should behave like the query used to define the scope' do
+        expect(Country.english_language.count).to eq 2
+        expect(Country.english_language.first.id).to eq 1
+        expect(Country.english_language.second.id).to eq 2
+      end
+    end
+    
+    context 'for query with argument' do
+      before do
+        Country.field :name
+        Country.field :language
+        Country.data = [
+          {:id => 1, :name => "US", :language => 'English'},
+          {:id => 2, :name => "Canada", :language => 'English'},
+          {:id => 3, :name => "Mexico", :language => 'Spanish'}
+        ]
+        Country.scope :with_language, ->(language) { where(language: language) }
+      end
+      
+      it 'should define a scope method' do
+        expect(Country.respond_to?(:with_language)).to be_truthy
+      end
+      
+      it 'should return the query used to define the scope' do
+        expect(Country.with_language('English')).to eq Country.where(language: 'English')
+      end
+      
+      it 'should behave like the query used to define the scope' do
+        expect(Country.with_language('English').count).to eq 2
+        expect(Country.with_language('English').first.id).to eq 1
+        expect(Country.with_language('English').second.id).to eq 2
+      end
+    end
+  end
 
 end

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -1375,6 +1375,22 @@ describe ActiveHash, "Base" do
         expect(Country.with_language('English').second.id).to eq 2
       end
     end
+    
+    context 'when scope body is not a lambda' do
+      before do
+        Country.field :name
+        Country.field :language
+        Country.data = [
+          {:id => 1, :name => "US", :language => 'English'},
+          {:id => 2, :name => "Canada", :language => 'English'},
+          {:id => 3, :name => "Mexico", :language => 'Spanish'}
+        ]
+      end
+      
+      it 'should raise an error' do
+        expect { Country.scope :invalid_scope, :not_a_callable }.to raise_error(ArgumentError, 'body needs to be callable')
+      end
+    end
   end
 
 end


### PR DESCRIPTION
This PR basically adds a `scope` class method comparable to the [interface of ActiveRecord](https://api.rubyonrails.org/classes/ActiveRecord/Scoping/Named/ClassMethods.html#method-i-scope).

Not sure how you handle contributions in general, happy to take your feedback.