### PR TITLE
Let `.find(nil)` raise ActiveHash::RecordNotFound (inspired by ActiveRecord)

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -261,14 +261,14 @@ module ActiveHash
 
       def find(id, * args)
         case id
-          when nil
-            nil
           when :all
             all
           when :first
             all(*args).first
           when Array
             id.map { |i| find(i) }
+          when nil
+            raise RecordNotFound.new("Couldn't find #{name} without an ID")
           else
             find_by_id(id) || begin
               raise RecordNotFound.new("Couldn't find #{name} with ID=#{id}")

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -601,6 +601,14 @@ describe ActiveHash, "Base" do
         end.should raise_error(ActiveHash::RecordNotFound, /Couldn't find Country with ID=0/)
       end
     end
+
+    context "with nil" do
+      it "raises ActiveHash::RecordNotFound when id is nil" do
+        proc do
+          Country.find(nil)
+        end.should raise_error(ActiveHash::RecordNotFound, /Couldn't find Country without an ID/)
+      end
+    end
   end
 
   describe ".find_by_id" do


### PR DESCRIPTION
I assume ActiveHash is implemented to behave like ActiveRecord.
I ran into the subtle issue below.

- ActiveRecord's `.find` method raises `ActiveRecord::RecordNotFound` when id is `nil`:
```
>> User
=> User(id: integer, name: string, created_at: datetime, updated_at: datetime)
>> User.all
  User Load (0.2ms)  SELECT  "users".* FROM "users" LIMIT ?  [["LIMIT", 11]]
=> #<ActiveRecord::Relation [#<User id: 1, name: "foo", created_at: "2019-06-07 14:00:15", updated_at: "2019-06-07 14:00:15">]>
>> User.find(nil)
Traceback (most recent call last):
        2: from (irb):13
        1: from (irb):13:in `rescue in irb_binding'
ActiveRecord::RecordNotFound (Couldn't find User without an ID)
```

- On the other hand, ActiveHash's `.find` method returns `nil` when given id=`nil`:
```
>> Nationality.all
=> [#<Nationality:0x00007fe2aa018620 @attributes={:id=>1, :name=>"US"}>, #<Nationality:0x00007fe2aa018328 @attributes={:id=>2, :name=>"Canada"}>]
>> Nationality.find(nil)
=> nil
```

So I suggest a change.

I know this change could affect some running applications which expect `.find(nil)` to return `nil`.
Though the interface of `.find` is not like ActiveRecord and I think it should be fixed.