### PR TITLE
`where` clause now works with range argument

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -200,6 +200,7 @@ module ActiveHash
         # use index if searching by id
         if options.key?(:id) || options.key?("id")
           ids = (options.delete(:id) || options.delete("id"))
+          ids = range_to_array(ids) if ids.is_a?(Range)
           candidates = Array.wrap(ids).map { |id| find_by_id(id) }.compact
         end
         return candidates if options.blank?
@@ -234,6 +235,15 @@ module ActiveHash
       end
 
       private :normalize
+
+      def range_to_array(range)
+        return range.to_a unless range.end.nil?
+
+        e = data.last[:id]
+        (range.begin..e).to_a
+      end
+
+      private :range_to_array
 
       def count
         all.length

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -281,6 +281,16 @@ describe ActiveHash, "Base" do
       expect(Country.where(:id => %w(1 2)).map(&:id)).to match_array([1,2])
     end
 
+    it "returns multiple records for range argument" do
+      expect(Country.where(:id => 1..2).map(&:id)).to match_array([1,2])
+    end
+
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.6.0")
+      it "returns multiple records for infinite range argument" do
+        expect(Country.where(:id => eval("2..")).map(&:id)).to match_array([2,3])
+      end
+    end
+
     it "filters records for multiple values" do
       expect(Country.where(:name => %w(US Canada)).map(&:name)).to match_array(%w(US Canada))
     end


### PR DESCRIPTION
This behavior is same as ActiveRecord.
We support **endless** range here, but doesn't support **beginless** range which will be introduced in Ruby 2.7.
That's because Rails 6 supports endless range only.
https://edgeguides.rubyonrails.org/6_0_release_notes.html#active-record-notable-changes