### PR TITLE
Add ActiveHash::Base.order method inspired by ActiveRecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Country.find_by(name: 'US')    # => returns the first country object with specif
 Country.find_by!(name: 'US')   # => same as find_by, but raise exception when not found
 Country.where(name: 'US')      # => returns all records with name: 'US'
 Country.where.not(name: 'US')  # => returns all records without name: 'US'
+Country.order(name: :desc)     # => returns all records ordered by name attribute in DESC order
 ```
 It also gives you a few dynamic finder methods.  For example, if you defined :name as a field, you'd get:
 ```ruby

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -188,59 +188,7 @@ module ActiveHash
         ActiveHash::Relation.new(self, @records || [], options[:conditions] || {})
       end
 
-      def order(*options)
-        check_if_method_has_arguments!(:order, options)
-        return @records if options.blank?
-
-        processed_args = preprocess_order_args(options)
-        candidates = @records.dup
-
-        order_by_args!(candidates, processed_args)
-
-        candidates
-      end
-
-      def check_if_method_has_arguments!(method_name, args)
-        if args.blank?
-          raise ArgumentError, "The method .#{method_name}() must contain arguments."
-        end
-      end
-
-      private :check_if_method_has_arguments!
-
-      def preprocess_order_args(order_args)
-        order_args.reject!(&:blank?)
-        return order_args.reverse! unless order_args.first.is_a?(String)
-
-        ary = order_args.first.split(", ")
-        ary.map! { |e| e.split(/\W+/) }.reverse!
-      end
-
-      private :preprocess_order_args
-
-      def order_by_args!(candidates, args)
-        args.each do |arg|
-          field, dir = if arg.is_a?(Hash)
-                         arg.to_a.flatten.map(&:to_sym)
-                       elsif arg.is_a?(Array)
-                         arg.map(&:to_sym)
-                       else
-                         arg.to_sym
-                       end
-
-          candidates.sort! do |a, b|
-            if dir.present? && dir.to_sym.upcase.equal?(:DESC)
-              b[field] <=> a[field]
-            else
-              a[field] <=> b[field]
-            end
-          end
-        end
-      end
-
-      private :order_by_args!
-
-      delegate :where, :find, :find_by, :find_by!, :find_by_id, :count, :pluck, :first, :last, to: :all
+      delegate :where, :find, :find_by, :find_by!, :find_by_id, :count, :pluck, :first, :last, :order, to: :all
 
       def transaction
         yield

--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -3,7 +3,7 @@ module ActiveHash
     include Enumerable
     
     delegate :each, to: :records # Make Enumerable work
-    delegate :equal?, :==, :===, :eql?, to: :records
+    delegate :equal?, :==, :===, :eql?, :sort!, to: :records
     delegate :empty?, :length, :first, :second, :third, :last, to: :records
         
     def initialize(klass, all_records, query_hash = nil)
@@ -71,7 +71,20 @@ module ActiveHash
     def reload
       @records = filter_all_records_by_query_hash
     end
-    
+
+    def order(*options)
+      check_if_method_has_arguments!(:order, options)
+      records = where({})
+      return records if options.blank?
+
+      processed_args = preprocess_order_args(options)
+      candidates = records.dup
+
+      order_by_args!(candidates, processed_args)
+
+      candidates
+    end
+
     attr_reader :query_hash, :klass, :all_records, :records_dirty
     
     private
@@ -123,6 +136,41 @@ module ActiveHash
 
       e = records.last[:id]
       (range.begin..e).to_a
+    end
+
+    def check_if_method_has_arguments!(method_name, args)
+      return unless args.blank?
+
+      raise ArgumentError,
+            "The method .#{method_name}() must contain arguments."
+    end
+
+    def preprocess_order_args(order_args)
+      order_args.reject!(&:blank?)
+      return order_args.reverse! unless order_args.first.is_a?(String)
+
+      ary = order_args.first.split(', ')
+      ary.map! { |e| e.split(/\W+/) }.reverse!
+    end
+
+    def order_by_args!(candidates, args)
+      args.each do |arg|
+        field, dir = if arg.is_a?(Hash)
+                       arg.to_a.flatten.map(&:to_sym)
+                     elsif arg.is_a?(Array)
+                       arg.map(&:to_sym)
+                     else
+                       arg.to_sym
+                     end
+
+        candidates.sort! do |a, b|
+          if dir.present? && dir.to_sym.upcase.equal?(:DESC)
+            b[field] <=> a[field]
+          else
+            a[field] <=> b[field]
+          end
+        end
+      end
     end
   end
 end

--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -74,11 +74,11 @@ module ActiveHash
 
     def order(*options)
       check_if_method_has_arguments!(:order, options)
-      records = where({})
-      return records if options.blank?
+      relation = where({})
+      return relation if options.blank?
 
       processed_args = preprocess_order_args(options)
-      candidates = records.dup
+      candidates = relation.dup
 
       order_by_args!(candidates, processed_args)
 

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -874,53 +874,60 @@ describe ActiveHash, "Base" do
     end
 
     it "returns all records when passed nil" do
-      expect(Country.order(nil)).to eq Country.all
+      expect(Country.order(nil).to_a).to eq Country.all.to_a
     end
 
     it "returns all records when an empty hash" do
-      expect(Country.order({})).to eq Country.all
+      expect(Country.order({}).to_a).to eq Country.all.to_a
     end
 
     it "returns all records ordered by name attribute in ASC order when ':name' is provieded" do
       countries = Country.order(:name)
-      expect(countries[0]).to eq Country.find_by(name: "Canada")
-      expect(countries[1]).to eq Country.find_by(name: "Mexico")
-      expect(countries[2]).to eq Country.find_by(name: "US")
+      expect(countries.first).to eq Country.find_by(name: "Canada")
+      expect(countries.second).to eq Country.find_by(name: "Mexico")
+      expect(countries.third).to eq Country.find_by(name: "US")
     end
 
     it "returns all records ordered by name attribute in DESC order when 'name: :desc' is provieded" do
       countries = Country.order(name: :desc)
-      expect(countries[0]).to eq Country.find_by(name: "US")
-      expect(countries[1]).to eq Country.find_by(name: "Mexico")
-      expect(countries[2]).to eq Country.find_by(name: "Canada")
+      expect(countries.first).to eq Country.find_by(name: "US")
+      expect(countries.second).to eq Country.find_by(name: "Mexico")
+      expect(countries.third).to eq Country.find_by(name: "Canada")
     end
 
-    it "returns all records ordered by code, followed by name in DESC order attribute in DESC order when ':code, name: :desc' is provieded" do
-      countries = Country.order(:code, name: :desc)
-      expect(countries[0]).to eq Country.find_by(name: "US")
-      expect(countries[1]).to eq Country.find_by(name: "Canada")
-      expect(countries[2]).to eq Country.find_by(name: "Mexico")
+    it "returns all records ordered by code attribute, followed by id attribute in DESC order when ':code, id: :desc' is provieded" do
+      countries = Country.order(:code, id: :desc)
+      expect(countries.first).to eq Country.find_by(name: "Canada")
+      expect(countries.second).to eq Country.find_by(name: "US")
+      expect(countries.third).to eq Country.find_by(name: "Mexico")
     end
 
     it "returns all records ordered by name attribute in ASC order when 'name' is provieded" do
       countries = Country.order("name")
-      expect(countries[0]).to eq Country.find_by(name: "Canada")
-      expect(countries[1]).to eq Country.find_by(name: "Mexico")
-      expect(countries[2]).to eq Country.find_by(name: "US")
+      expect(countries.first).to eq Country.find_by(name: "Canada")
+      expect(countries.second).to eq Country.find_by(name: "Mexico")
+      expect(countries.third).to eq Country.find_by(name: "US")
     end
 
     it "returns all records ordered by name attribute in DESC order when 'name: :desc' is provieded" do
       countries = Country.order("name DESC")
-      expect(countries[0]).to eq Country.find_by(name: "US")
-      expect(countries[1]).to eq Country.find_by(name: "Mexico")
-      expect(countries[2]).to eq Country.find_by(name: "Canada")
+      expect(countries.first).to eq Country.find_by(name: "US")
+      expect(countries.second).to eq Country.find_by(name: "Mexico")
+      expect(countries.third).to eq Country.find_by(name: "Canada")
     end
 
-    it "returns all records ordered by code, followed by name in DESC order attribute in DESC order when ':code, name: :desc' is provieded" do
-      countries = Country.order("code, name DESC")
-      expect(countries[0]).to eq Country.find_by(name: "US")
-      expect(countries[1]).to eq Country.find_by(name: "Canada")
-      expect(countries[2]).to eq Country.find_by(name: "Mexico")
+    it "returns all records ordered by code attributes, followed by id attribute in DESC order when ':code, id: :desc' is provieded" do
+      countries = Country.order("code, id DESC")
+      expect(countries.first).to eq Country.find_by(name: "Canada")
+      expect(countries.second).to eq Country.find_by(name: "US")
+      expect(countries.third).to eq Country.find_by(name: "Mexico")
+    end
+
+    it "populates the data correctly in the order provided" do
+      countries = Country.where(language: 'English').order(id: :desc)
+      expect(countries.count).to eq 2
+      expect(countries.first).to eq Country.find_by(name: "Canada")
+      expect(countries.second).to eq Country.find_by(name: "US")
     end
   end
 

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -839,6 +839,73 @@ describe ActiveHash, "Base" do
     end
   end
 
+  describe ".order" do
+    before do
+      Country.field :name
+      Country.field :language
+      Country.field :code
+      Country.data = [
+        { id: 1, name: "US",     language: "English", code: 1 },
+        { id: 2, name: "Canada", language: "English", code: 1 },
+        { id: 3, name: "Mexico", language: "Spanish", code: 52 }
+      ]
+    end
+
+    it "raises ArgumentError if no args are provieded" do
+      expect { Country.order() }.to raise_error(ArgumentError, 'The method .order() must contain arguments.')
+    end
+
+    it "returns all records when passed nil" do
+      expect(Country.order(nil)).to eq Country.all
+    end
+
+    it "returns all records when an empty hash" do
+      expect(Country.order({})).to eq Country.all
+    end
+
+    it "returns all records ordered by name attribute in ASC order when ':name' is provieded" do
+      countries = Country.order(:name)
+      expect(countries[0]).to eq Country.find_by(name: "Canada")
+      expect(countries[1]).to eq Country.find_by(name: "Mexico")
+      expect(countries[2]).to eq Country.find_by(name: "US")
+    end
+
+    it "returns all records ordered by name attribute in DESC order when 'name: :desc' is provieded" do
+      countries = Country.order(name: :desc)
+      expect(countries[0]).to eq Country.find_by(name: "US")
+      expect(countries[1]).to eq Country.find_by(name: "Mexico")
+      expect(countries[2]).to eq Country.find_by(name: "Canada")
+    end
+
+    it "returns all records ordered by code, followed by name in DESC order attribute in DESC order when ':code, name: :desc' is provieded" do
+      countries = Country.order(:code, name: :desc)
+      expect(countries[0]).to eq Country.find_by(name: "US")
+      expect(countries[1]).to eq Country.find_by(name: "Canada")
+      expect(countries[2]).to eq Country.find_by(name: "Mexico")
+    end
+
+    it "returns all records ordered by name attribute in ASC order when 'name' is provieded" do
+      countries = Country.order("name")
+      expect(countries[0]).to eq Country.find_by(name: "Canada")
+      expect(countries[1]).to eq Country.find_by(name: "Mexico")
+      expect(countries[2]).to eq Country.find_by(name: "US")
+    end
+
+    it "returns all records ordered by name attribute in DESC order when 'name: :desc' is provieded" do
+      countries = Country.order("name DESC")
+      expect(countries[0]).to eq Country.find_by(name: "US")
+      expect(countries[1]).to eq Country.find_by(name: "Mexico")
+      expect(countries[2]).to eq Country.find_by(name: "Canada")
+    end
+
+    it "returns all records ordered by code, followed by name in DESC order attribute in DESC order when ':code, name: :desc' is provieded" do
+      countries = Country.order("code, name DESC")
+      expect(countries[0]).to eq Country.find_by(name: "US")
+      expect(countries[1]).to eq Country.find_by(name: "Canada")
+      expect(countries[2]).to eq Country.find_by(name: "Mexico")
+    end
+  end
+
   describe "#method_missing" do
     it "doesn't blow up if you call a missing dynamic finder when fields haven't been set" do
       proc do


### PR DESCRIPTION
This PR basically tries to add `ActiveHash::Base.order` class method.
Kindly consider my request, happy to take your feedback.
Thanks.