### PR TITLE
Make #where chainable

### DIFF
--- a/active_hash.gemspec
+++ b/active_hash.gemspec
@@ -45,5 +45,6 @@ Gem::Specification.new do |s|
   ].flatten
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
   s.add_runtime_dependency('activesupport', '>= 5.0.0')
+  s.add_development_dependency "pry"
   s.required_ruby_version = '>= 2.4.0'
 end

--- a/lib/active_hash.rb
+++ b/lib/active_hash.rb
@@ -12,6 +12,7 @@ rescue LoadError
 end
 
 require 'active_hash/base'
+require 'active_hash/result_set'
 require 'active_file/multiple_files'
 require 'active_file/hash_and_array_files'
 require 'active_file/base'

--- a/lib/active_hash.rb
+++ b/lib/active_hash.rb
@@ -12,7 +12,7 @@ rescue LoadError
 end
 
 require 'active_hash/base'
-require 'active_hash/result_set'
+require 'active_hash/relation'
 require 'active_file/multiple_files'
 require 'active_file/hash_and_array_files'
 require 'active_file/base'

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -36,7 +36,7 @@ module ActiveHash
           match_options?(record, options)
         end
         
-        ActiveHash::ResultSet.new(@scope.klass, filtered_records, {})
+        ActiveHash::Relation.new(@scope.klass, filtered_records, {})
       end
 
       def match_options?(record, options)
@@ -185,7 +185,7 @@ module ActiveHash
       end
 
       def all(options = {})
-        ActiveHash::ResultSet.new(self, @records || [], options[:conditions] || {})
+        ActiveHash::Relation.new(self, @records || [], options[:conditions] || {})
       end
 
       delegate :where, :find, :find_by, :find_by!, :find_by_id, :count, :pluck, :first, :last, to: :all

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -23,7 +23,7 @@ module ActiveHash
       end
 
       def not(options)
-        return @records if options.blank?
+        return @scope if options.blank?
 
         # use index if searching by id
         if options.key?(:id) || options.key?("id")
@@ -32,9 +32,11 @@ module ActiveHash
         end
         return candidates if options.blank?
 
-        (candidates || @records || []).reject do |record|
+        filtered_records = (candidates || @records || []).reject do |record|
           match_options?(record, options)
         end
+        
+        ActiveHash::ResultSet.new(@scope.klass, filtered_records, {})
       end
 
       def match_options?(record, options)

--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -182,33 +182,11 @@ module ActiveHash
         record
       end
 
-      def all(options={})
-        if options.has_key?(:conditions)
-          where(options[:conditions])
-        else
-          @records ||= []
-        end
+      def all(options = {})
+        ActiveHash::ResultSet.new(self, @records || [], options[:conditions] || {})
       end
 
-      def where(options = :chain)
-        if options == :chain
-          return WhereChain.new(self)
-        elsif options.blank?
-          return @records
-        end
-
-        # use index if searching by id
-        if options.key?(:id) || options.key?("id")
-          ids = (options.delete(:id) || options.delete("id"))
-          ids = range_to_array(ids) if ids.is_a?(Range)
-          candidates = Array.wrap(ids).map { |id| find_by_id(id) }.compact
-        end
-        return candidates if options.blank?
-
-        (candidates || @records || []).select do |record|
-          match_options?(record, options)
-        end
-      end
+      delegate :where, to: :all
 
       def find_by(options)
         where(options).first

--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -4,9 +4,8 @@ module ActiveHash
     
     delegate :each, to: :records # Make Enumerable work
     delegate :equal?, :==, :===, :eql?, to: :records
-    
-    delegate_missing_to :records
-    
+    delegate :empty?, :length, :first, :second, :third, :last, to: :records
+        
     def initialize(klass, all_records, query_hash = nil)
       self.klass = klass
       self.all_records = all_records

--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -1,5 +1,5 @@
 module ActiveHash
-  class ResultSet
+  class Relation
     include Enumerable
     
     delegate :each, to: :records # Make Enumerable work

--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -38,7 +38,7 @@ module ActiveHash
       find_by(options) || (raise RecordNotFound.new("Couldn't find #{klass.name}"))
     end
     
-    def find(id, * args)
+    def find(id, *args)
       case id
         when :all
           all

--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -57,7 +57,7 @@ module ActiveHash
     end
     
     def find_by_id(id)
-      index = klass.send(:record_index)[id.to_s] # TODO: don't use send
+      index = klass.send(:record_index)[id.to_s] # TODO: Make index in Base publicly readable instead of using send?
       index and records[index]
     end
     
@@ -73,15 +73,15 @@ module ActiveHash
       @records = filter_all_records_by_query_hash
     end
     
-    attr_accessor :query_hash, :klass, :all_records, :records_dirty
+    attr_reader :query_hash, :klass, :all_records, :records_dirty
     
     private
     
-    #attr_accessor :query_hash, :klass, :all_records
+    attr_writer :query_hash, :klass, :all_records, :records_dirty
     
     def records
       if @records.nil? || records_dirty
-        @records = filter_all_records_by_query_hash
+        reload
       else
         @records
       end
@@ -125,6 +125,5 @@ module ActiveHash
       e = records.last[:id]
       (range.begin..e).to_a
     end
-
   end
 end

--- a/lib/active_hash/result_set.rb
+++ b/lib/active_hash/result_set.rb
@@ -3,7 +3,6 @@ module ActiveHash
     include Enumerable
     
     delegate :each, to: :records # Make Enumerable work
-    
     delegate :equal?, :==, :===, :eql?, to: :records
     
     delegate_missing_to :records

--- a/lib/active_hash/result_set.rb
+++ b/lib/active_hash/result_set.rb
@@ -1,0 +1,73 @@
+module ActiveHash
+  class ResultSet
+    include Enumerable
+    
+    delegate :each, to: :records # Make Enumerable work
+    
+    delegate :first, :last, :length, to: :records
+    
+    def initialize(klass, all_records, query_hash = {})
+      self.klass = klass
+      self.all_records = all_records
+      self.query_hash = query_hash
+    end
+    
+    def where(query_hash = nil)
+      return ActiveHash::Base::WhereChain.new(self.query_hash) if query_hash.nil?
+      
+      self.query_hash.merge!(query_hash)
+      self
+    end
+    
+    def reload
+      @records = filter_all_records_by_query_hash
+    end
+    
+    attr_accessor :query_hash, :klass, :all_records
+    
+    private
+    
+    #attr_accessor :query_hash, :klass, :all_records
+    
+    def records
+      @records ||= filter_all_records_by_query_hash
+    end
+    
+    def filter_all_records_by_query_hash
+      # use index if searching by id
+      if query_hash.key?(:id) || query_hash.key?("id")
+        ids = (query_hash.delete(:id) || query_hash.delete("id"))
+        ids = range_to_array(ids) if ids.is_a?(Range)
+        candidates = Array.wrap(ids).map { |id| klass.find_by_id(id) }.compact
+      end
+      
+      return candidates if query_hash.blank?
+
+      (candidates || all_records || []).select do |record|
+        match_options?(record, query_hash)
+      end
+    end
+    
+    def match_options?(record, options)
+      options.all? do |col, match|
+        if match.kind_of?(Array)
+          match.any? { |v| normalize(v) == normalize(record[col]) }
+        else
+          normalize(record[col]) == normalize(match)
+        end
+      end
+    end
+
+    def normalize(v)
+      v.respond_to?(:to_sym) ? v.to_sym : v
+    end
+    
+    def range_to_array(range)
+      return range.to_a unless range.end.nil?
+
+      e = data.last[:id]
+      (range.begin..e).to_a
+    end
+
+  end
+end

--- a/lib/active_hash/result_set.rb
+++ b/lib/active_hash/result_set.rb
@@ -4,36 +4,82 @@ module ActiveHash
     
     delegate :each, to: :records # Make Enumerable work
     
-    delegate :first, :last, :length, to: :records
+    delegate :first, :last, :length, :equal?, :==, :===, :eql?, to: :records
     
-    def initialize(klass, all_records, query_hash = {})
+    delegate_missing_to :records
+    
+    def initialize(klass, all_records, query_hash = nil)
       self.klass = klass
       self.all_records = all_records
       self.query_hash = query_hash
+      self.records_dirty = false
+      self
     end
     
-    def where(query_hash = nil)
-      return ActiveHash::Base::WhereChain.new(self.query_hash) if query_hash.nil?
+    def where(query_hash = :chain)
+      return ActiveHash::Base::WhereChain.new(self) if query_hash == :chain
       
-      self.query_hash.merge!(query_hash)
+      self.records_dirty = true unless query_hash.nil? || query_hash.keys.empty?
+      self.query_hash.merge!(query_hash || {})
       self
+    end
+    
+    def all
+      where({})
+    end
+    
+    def find_by(options)
+      where(options).first
+    end
+
+    def find_by!(options)
+      find_by(options) || (raise RecordNotFound.new("Couldn't find #{name}"))
+    end
+    
+    def find(id, * args)
+      case id
+        when :all
+          all
+        when :first
+          all(*args).first
+        when Array
+          id.map { |i| find(i) }
+        when nil
+          raise RecordNotFound.new("Couldn't find #{name} without an ID")
+        else
+          find_by_id(id) || begin
+            raise RecordNotFound.new("Couldn't find #{name} with ID=#{id}")
+          end
+      end
+    end
+    
+    def find_by_id(id)
+      index = klass.send(:record_index)[id.to_s] # TODO: don't use send
+      index and records[index]
     end
     
     def reload
       @records = filter_all_records_by_query_hash
     end
     
-    attr_accessor :query_hash, :klass, :all_records
+    attr_accessor :query_hash, :klass, :all_records, :records_dirty
     
     private
     
     #attr_accessor :query_hash, :klass, :all_records
     
     def records
-      @records ||= filter_all_records_by_query_hash
+      if @records.nil? || records_dirty
+        @records = filter_all_records_by_query_hash
+      else
+        @records
+      end
     end
     
     def filter_all_records_by_query_hash
+      self.records_dirty = false
+      return all_records if query_hash.blank?
+      
       # use index if searching by id
       if query_hash.key?(:id) || query_hash.key?("id")
         ids = (query_hash.delete(:id) || query_hash.delete("id"))
@@ -65,7 +111,7 @@ module ActiveHash
     def range_to_array(range)
       return range.to_a unless range.end.nil?
 
-      e = data.last[:id]
+      e = records.last[:id]
       (range.begin..e).to_a
     end
 

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -215,6 +215,10 @@ describe ActiveHash, "Base" do
         {:id => 3, :name => "Mexico", :language => 'Spanish'}
       ]
     end
+    
+    it 'returns a ResultSet class if conditions are provided' do
+      Country.where(language: 'English').class.should == ActiveHash::ResultSet
+    end
 
     it "returns WhereChain class if no conditions are provided" do
       Country.where.class.should == ActiveHash::Base::WhereChain
@@ -325,6 +329,10 @@ describe ActiveHash, "Base" do
       lambda{
         Country.where.not
       }.should raise_error(ArgumentError)
+    end
+    
+    it 'returns a chainable ResultSet when conditions are passed' do
+      Country.where.not(language: 'Spanish').class.should == ActiveHash::ResultSet
     end
 
     it "returns all records when passed nil" do

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -221,11 +221,11 @@ describe ActiveHash, "Base" do
     end
 
     it "returns all records when passed nil" do
-      Country.where(nil).should == Country.all
+      Country.where(nil).to_a.should == Country.all.to_a
     end
 
     it "returns all records when an empty hash" do
-      Country.where({}).should == Country.all
+      Country.where({}).to_a.should == Country.all.to_a
     end
 
     it "returns all data as inflated objects" do
@@ -298,6 +298,16 @@ describe ActiveHash, "Base" do
     it "filters records for multiple symbol values" do
       expect(Country.where(:name => [:US, :Canada]).map(&:name)).to match_array(%w(US Canada))
     end
+    
+    it 'is chainable' do
+      where_relation = Country.where(language: 'English')
+      
+      expect(where_relation.length).to eq 2
+      expect(where_relation.map(&:id)).to eq([1, 2])
+      chained_where_relation = where_relation.where(name: 'US')
+      expect(chained_where_relation.length).to eq 1
+      expect(chained_where_relation.map(&:id)).to eq([1])
+    end
   end
 
   describe ".where.not" do
@@ -318,11 +328,11 @@ describe ActiveHash, "Base" do
     end
 
     it "returns all records when passed nil" do
-      Country.where.not(nil).should == Country.all
+      Country.where.not(nil).to_a.should == Country.all.to_a
     end
 
     it "returns all records when an empty hash" do
-      Country.where.not({}).should == Country.all
+      Country.where.not({}).to_a.should == Country.all.to_a
     end
 
     it "returns all records as inflated objects" do
@@ -366,7 +376,7 @@ describe ActiveHash, "Base" do
     end
 
     it "returns all records when id is nil" do
-      expect(Country.where.not(:id => nil)).to eq Country.all
+      expect(Country.where.not(:id => nil).to_a).to eq Country.all.to_a
     end
 
     it "filters records for multiple ids" do

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -400,7 +400,7 @@ describe ActiveHash, "Base" do
     end
 
     it "filters records for multiple conditions" do
-      expect(Country.where.not(:id => 1, :name => 'Mexico')).to match_array([Country.find(2)])
+      expect(Country.where.not(:id => 1, :name => 'Mexico').to_a).to match_array([Country.find(2)])
     end
   end
 
@@ -1375,7 +1375,7 @@ describe ActiveHash, "Base" do
       end
       
       it 'should return the query used to define the scope' do
-        expect(Country.english_language).to eq Country.where(language: 'English')
+        expect(Country.english_language.to_a).to eq Country.where(language: 'English').to_a
       end
       
       it 'should behave like the query used to define the scope' do
@@ -1402,7 +1402,7 @@ describe ActiveHash, "Base" do
       end
       
       it 'should return the query used to define the scope' do
-        expect(Country.with_language('English')).to eq Country.where(language: 'English')
+        expect(Country.with_language('English').to_a).to eq Country.where(language: 'English').to_a
       end
       
       it 'should behave like the query used to define the scope' do

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -216,8 +216,8 @@ describe ActiveHash, "Base" do
       ]
     end
     
-    it 'returns a ResultSet class if conditions are provided' do
-      Country.where(language: 'English').class.should == ActiveHash::ResultSet
+    it 'returns a Relation class if conditions are provided' do
+      Country.where(language: 'English').class.should == ActiveHash::Relation
     end
 
     it "returns WhereChain class if no conditions are provided" do
@@ -331,8 +331,8 @@ describe ActiveHash, "Base" do
       }.should raise_error(ArgumentError)
     end
     
-    it 'returns a chainable ResultSet when conditions are passed' do
-      Country.where.not(language: 'Spanish').class.should == ActiveHash::ResultSet
+    it 'returns a chainable Relation when conditions are passed' do
+      Country.where.not(language: 'Spanish').class.should == ActiveHash::Relation
     end
 
     it "returns all records when passed nil" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require "bundler/setup"
+require "pry"
 require 'rspec'
 require 'rspec/autorun'
 require 'yaml'


### PR DESCRIPTION
In #173 I committed to working on a change that makes the `#where` method chainable, just like in ActiveRecord. I often wished this was possible when using ActiveHash and it makes the `::scope` method from #173 much more useful.

Basically I introduced an `ActiveHash::Relation` class, which represents a relation/query and can be chained as often as one would like. `ActiveHash::Base` returns a relation instance when `::all` is called. All other query methods (such as `find_by` etc.) moved to `ActiveHash::Relation`. You can still call them from the base class though (they are being delegated to `::all` which as mentioned above returns a relation). `ActiveHash::Relation` also implements `Enumerable`, so you don't have to call `#to_a` explicitly. Therefore the interface of active hash classes does not really change, but is just a bit more powerful.

Please let me know what you think and what I can improve in the implementation (there is one comment about accessing the index from the relation class which is not done very nicely atm).