### PR TITLE
Add #to_ary to ActiveHash::Relation

### DIFF
--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -72,6 +72,10 @@ module ActiveHash
       @records = filter_all_records_by_query_hash
     end
     
+    def to_ary
+      records.dup
+    end
+    
     attr_reader :query_hash, :klass, :all_records, :records_dirty
     
     private

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -225,11 +225,11 @@ describe ActiveHash, "Base" do
     end
 
     it "returns all records when passed nil" do
-      Country.where(nil).to_a.should == Country.all.to_a
+      Country.where(nil).should == Country.all
     end
 
     it "returns all records when an empty hash" do
-      Country.where({}).to_a.should == Country.all.to_a
+      Country.where({}).should == Country.all
     end
 
     it "returns all data as inflated objects" do
@@ -336,11 +336,11 @@ describe ActiveHash, "Base" do
     end
 
     it "returns all records when passed nil" do
-      Country.where.not(nil).to_a.should == Country.all.to_a
+      Country.where.not(nil).should == Country.all
     end
 
     it "returns all records when an empty hash" do
-      Country.where.not({}).to_a.should == Country.all.to_a
+      Country.where.not({}).should == Country.all
     end
 
     it "returns all records as inflated objects" do
@@ -384,7 +384,7 @@ describe ActiveHash, "Base" do
     end
 
     it "returns all records when id is nil" do
-      expect(Country.where.not(:id => nil).to_a).to eq Country.all.to_a
+      expect(Country.where.not(:id => nil)).to eq Country.all
     end
 
     it "filters records for multiple ids" do
@@ -400,7 +400,7 @@ describe ActiveHash, "Base" do
     end
 
     it "filters records for multiple conditions" do
-      expect(Country.where.not(:id => 1, :name => 'Mexico').to_a).to match_array([Country.find(2)])
+      expect(Country.where.not(:id => 1, :name => 'Mexico')).to match_array([Country.find(2)])
     end
   end
 
@@ -1375,7 +1375,7 @@ describe ActiveHash, "Base" do
       end
       
       it 'should return the query used to define the scope' do
-        expect(Country.english_language.to_a).to eq Country.where(language: 'English').to_a
+        expect(Country.english_language).to eq Country.where(language: 'English')
       end
       
       it 'should behave like the query used to define the scope' do
@@ -1402,7 +1402,7 @@ describe ActiveHash, "Base" do
       end
       
       it 'should return the query used to define the scope' do
-        expect(Country.with_language('English').to_a).to eq Country.where(language: 'English').to_a
+        expect(Country.with_language('English')).to eq Country.where(language: 'English')
       end
       
       it 'should behave like the query used to define the scope' do

--- a/spec/active_hash/relation_spec.rb
+++ b/spec/active_hash/relation_spec.rb
@@ -1,14 +1,16 @@
 require 'spec_helper'
 
 RSpec.describe ActiveHash::Relation do
-  class Country < ActiveHash::Base
-    self.data = [
-      {:id => 1, :name => "US"},
-      {:id => 2, :name => "Canada"}
-    ]
+  let(:model_class) do
+    Class.new(ActiveHash::Base) do
+      self.data = [
+        {:id => 1, :name => "US"},
+        {:id => 2, :name => "Canada"}
+      ]
+    end
   end
   
-  subject { Country.all }
+  subject { model_class.all }
   
   describe '#to_ary' do
     it 'returns an array' do

--- a/spec/active_hash/relation_spec.rb
+++ b/spec/active_hash/relation_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe ActiveHash::Relation do
+  class Country < ActiveHash::Base
+    self.data = [
+      {:id => 1, :name => "US"},
+      {:id => 2, :name => "Canada"}
+    ]
+  end
+  
+  subject { Country.all }
+  
+  describe '#to_ary' do
+    it 'returns an array' do
+      expect(subject.to_ary).to be_an(Array)
+    end
+    
+    it 'contains the same items as the relation' do
+      array = subject.to_ary
+      
+      expect(array.length).to eq(subject.count)
+      expect(array.first.id).to eq(1)
+      expect(array.second.id).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds `#to_ary` to `ActiveHash::Relation`, which returns a `#dup`ed array of the items of the relation. When upgrading to active_hash 3.0.0, the following line in a controller that used [active_model_serializers](https://github.com/rails-api/active_model_serializers) to return a collection of items of an ActiveHash data store did not work anymore, because active_model_serializers uses `#respond_to?(:to_ary)` to determine if an object is a collection or not (`ActiveRecord::Relation` does respond to this method). After this PR, this should work again.

```ruby
render json: MyActiveHashClass.all, each_serializer: MyActiveHashClassSerializer
```

I put the spec for this new method into a new file `spec/active_hash/relation_spec.rb`, because it would not really belong to the `base_spec.rb`.