### PR TITLE
Allow #find to behave like Enumerable#find if id is nil and a block is given

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Country.find 1                 # => returns the first country object with that i
 Country.find [1,2]             # => returns all Country objects with ids in the array
 Country.find :all              # => same as .all
 Country.find :all, args        # => the second argument is totally ignored, but allows it to play nicely with AR
+Country.find { |country| country.name.start_with?('U') } # => returns the first country for which the block evaluates to true
 Country.find_by_id 1           # => find the first object that matches the id
 Country.find_by(name: 'US')    # => returns the first country object with specified argument
 Country.find_by!(name: 'US')   # => same as find_by, but raise exception when not found

--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -38,7 +38,7 @@ module ActiveHash
       find_by(options) || (raise RecordNotFound.new("Couldn't find #{klass.name}"))
     end
     
-    def find(id, *args)
+    def find(id = nil, *args, &block)
       case id
         when :all
           all
@@ -47,7 +47,8 @@ module ActiveHash
         when Array
           id.map { |i| find(i) }
         when nil
-          raise RecordNotFound.new("Couldn't find #{klass.name} without an ID")
+          raise RecordNotFound.new("Couldn't find #{klass.name} without an ID") unless block_given?
+          records.find(&block) # delegate to Enumerable#find if a block is given
         else
           find_by_id(id) || begin
             raise RecordNotFound.new("Couldn't find #{klass.name} with ID=#{id}")

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -631,10 +631,21 @@ describe ActiveHash, "Base" do
     end
 
     context "with nil" do
-      it "raises ActiveHash::RecordNotFound when id is nil" do
-        proc do
-          Country.find(nil)
-        end.should raise_error(ActiveHash::RecordNotFound, /Couldn't find Country without an ID/)
+      context 'and no block' do
+        it "raises ActiveHash::RecordNotFound when id is nil" do
+          proc do
+            Country.find(nil)
+          end.should raise_error(ActiveHash::RecordNotFound, /Couldn't find Country without an ID/)
+        end
+      end
+      
+      context 'and a block' do
+        it 'finds the record by evaluating the block' do
+          country = Country.find { |c| c.id == 1 }
+          
+          expect(country).to be_a(Country)
+          expect(country.name).to eq('US')
+        end
       end
     end
   end


### PR DESCRIPTION
We discovered in our codebase that we often used `#find` chained after a `#where` or `#all` query, which used to invoke `Enumerable#find` because an `Array` was returned.

Since those methods are chainable now and return an `ActiveHash::Relation`, `#find` calls invoked the implementation in the relation class.

This change makes `ActiveHash::Relation#find` compatible with both the query variant (find by id) as well as with the `Enumerable` variant (find by block criteria). This is how active record behaves, too.