### PR TITLE
Remove redundant to_ary methods

### DIFF
--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -885,11 +885,11 @@ describe ActiveHash, "Base" do
     end
 
     it "returns all records when passed nil" do
-      expect(Country.order(nil).to_a).to eq Country.all.to_a
+      expect(Country.order(nil)).to eq Country.all
     end
 
     it "returns all records when an empty hash" do
-      expect(Country.order({}).to_a).to eq Country.all.to_a
+      expect(Country.order({})).to eq Country.all
     end
 
     it "returns all records ordered by name attribute in ASC order when ':name' is provieded" do


### PR DESCRIPTION
## Summary
- Remove redundant `#to_ary` calls after addition of `#to_ary` method to `ActiveHash::Relation` https://github.com/zilkey/active_hash/pull/182