### PR TITLE
Delegate :sample to `records`

### DIFF
--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -5,6 +5,7 @@ module ActiveHash
     delegate :each, to: :records # Make Enumerable work
     delegate :equal?, :==, :===, :eql?, :sort!, to: :records
     delegate :empty?, :length, :first, :second, :third, :last, to: :records
+    delegate :sample, to: :records
         
     def initialize(klass, all_records, query_hash = nil)
       self.klass = klass

--- a/spec/active_hash/relation_spec.rb
+++ b/spec/active_hash/relation_spec.rb
@@ -11,6 +11,19 @@ RSpec.describe ActiveHash::Relation do
   end
   
   subject { model_class.all }
+
+  describe '#sample' do
+    it 'delegate `sample` to Array' do
+      expect(subject).to respond_to(:sample)
+    end
+
+    it 'return a random element or n random elements' do
+      records = subject
+
+      expect(records.sample).to be_present
+      expect(records.sample(2).count).to eq(2)
+    end
+  end
   
   describe '#to_ary' do
     it 'returns an array' do


### PR DESCRIPTION
In this PR, delegate macro will accept `#sample` method to `records` ([same as ActiveRecord](https://github.com/rails/rails/blob/b13c518ddf5912c5d4fe69d508f7af04bb3b515c/activerecord/lib/active_record/relation/delegation.rb#L86))

before
```
[1] pry(main)> Foo.all.sample
NoMethodError: undefined method `sample' for #<ActiveHash::Relation:0x000055874716f4f8>

[2] pry(main)> Foo.all.to_a.sample
=> #<Foo:0x000055873fe07920 @attributes={:id=>3, :type=>"BAZ"}>
```

after
```
[1] pry(main)> Foo.all.sample
=> #<Foo:0x000055b80956ca40 @attributes={:id=>2, :type=>"BAR"}>
```