### PR TITLE
CI against ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ before_install:
   - gem update bundler
 
 rvm:
-  - "2.4.5"
-  - "2.5.3"
-  - "2.6.1"
+  - "2.4.9"
+  - "2.5.7"
+  - "2.6.5"
+  - "2.7.0"
 gemfile:
   - gemfiles/rails_5.0.gemfile
   - gemfiles/rails_5.1.gemfile
@@ -16,7 +17,7 @@ gemfile:
 
 matrix:
   exclude:
-    - rvm: 2.4.5
+    - rvm: 2.4.9
       gemfile: gemfiles/rails_6.0.gemfile
 
 script: "bundle exec rake spec"


### PR DESCRIPTION
Released on 25 Dec 2019
https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/