### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 gem 'rspec', '~> 2.2.0'
 gem 'wwtd'
-gem 'rake'
+gem 'rake', '~> 10.0'
 gem 'test-unit'
 
 if RUBY_VERSION < "2"

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ platforms :jruby do
 end
 
 platforms :ruby do
-  gem 'sqlite3', '~> 1.3.0'
+  gem 'sqlite3', '~> 1.4.0'
 end
 
 gem 'activerecord', '>= 5.0.0'


### PR DESCRIPTION
## Summary

In case of using `'activerecord', '>= 5.0.0'`, it need to use `'rake', '~> 10.0'` and `'sqlite3', '~> 1.4.0'` as same as `gemfiles/rails_6.0.gemfile`.

## Error messages

### rake

It looks rake v12.0 or higher is unavailable.

```
% bundle
% bundle exec rake -T
rake aborted!
NoMethodError: undefined method `last_comment' for #<Rake::Application:0x000055cb16dff3b8>
/home/yhirano55/src/github.com/yhirano55/active_hash/vendor/bundle/gems/rspec-core-2.99.2/lib/rspec/core/rake_task.rb:143:in `initialize'
/home/yhirano55/src/github.com/yhirano55/active_hash/Rakefile:6:in `new'
/home/yhirano55/src/github.com/yhirano55/active_hash/Rakefile:6:in `<top (required)>'
/home/yhirano55/src/github.com/yhirano55/active_hash/vendor/bundle/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/home/yhirano55/.rbenv/versions/2.6.5/bin/bundle:23:in `load'
/home/yhirano55/.rbenv/versions/2.6.5/bin/bundle:23:in `<main>'
(See full trace by running task with --trace)
```

### sqlite3

Rails requires sqlite `~> 1.4.0`, but it sets '~> 1.3.0'. So it cannot load its library.

https://github.com/rails/rails/blob/6-0-stable/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L13

Thanks.