### PR TITLE
Testable per file

### DIFF
--- a/spec/associations/active_record_extensions_spec.rb
+++ b/spec/associations/active_record_extensions_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 unless SKIP_ACTIVE_RECORD
-  require 'active_record'
   describe ActiveHash::Base, "active record extensions" do
 
     before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ SKIP_ACTIVE_RECORD = ENV['SKIP_ACTIVE_RECORD']
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'active_hash'
+require 'active_record' unless SKIP_ACTIVE_RECORD
 
 Dir["spec/support/**/*.rb"].each { |f|
   require File.expand_path(f)


### PR DESCRIPTION
## Summary

I've noticed that it could not testable per file (only `spec/active_hash/base_spec.rb`). So I make it testable per file.

### Before

```
% bundle exec rspec spec/active_hash/base_spec.rb
...................................................................................................................................................................
An error occurred in an after hook
  NameError: constant Object::Book not defined
  occurred at /home/yhirano55/src/github.com/yhirano55/active_hash/spec/active_hash/base_spec.rb:1249:in `remove_const'

F
An error occurred in an after hook
  NameError: constant Object::Book not defined
  occurred at /home/yhirano55/src/github.com/yhirano55/active_hash/spec/active_hash/base_spec.rb:1249:in `remove_const'

F..................F..........

Failures:

  1) ActiveHash Base using with belongs_to in ActiveRecord should be possible to use it as a parent
     Failure/Error: class Book < ActiveRecord::Base
     NameError:
       uninitialized constant ActiveRecord
       Did you mean?  ActiveModel
     # ./spec/active_hash/base_spec.rb:1236:in `block (3 levels) in <top (required)>'

  2) ActiveHash Base using with belongs_to in ActiveRecord should be possible to use it as a polymorphic parent
     Failure/Error: class Book < ActiveRecord::Base
     NameError:
       uninitialized constant ActiveRecord
       Did you mean?  ActiveModel
     # ./spec/active_hash/base_spec.rb:1236:in `block (3 levels) in <top (required)>'

  3) ActiveHash Base .transaction swallows ActiveRecord::Rollback errors
     Failure/Error: proc do
       expected no Exception, got #<NameError: uninitialized constant ActiveRecord
       Did you mean?  ActiveModel> with backtrace:
         # ./spec/active_hash/base_spec.rb:1429:in `block (5 levels) in <top (required)>'
         # ./lib/active_hash/base.rb:194:in `transaction'
         # ./spec/active_hash/base_spec.rb:1428:in `block (4 levels) in <top (required)>'
         # ./spec/active_hash/base_spec.rb:1427:in `block (3 levels) in <top (required)>'
     # ./spec/active_hash/base_spec.rb:1427:in `block (3 levels) in <top (required)>'

Finished in 0.10309 seconds
194 examples, 3 failures

Failed examples:

rspec ./spec/active_hash/base_spec.rb:1252 # ActiveHash Base using with belongs_to in ActiveRecord should be possible to use it as a parent
rspec ./spec/active_hash/base_spec.rb:1258 # ActiveHash Base using with belongs_to in ActiveRecord should be possible to use it as a polymorphic parent
rspec ./spec/active_hash/base_spec.rb:1426 # ActiveHash Base .transaction swallows ActiveRecord::Rollback errors
```

### After

```
% bundle exec rspec spec/active_hash/base_spec.rb
..................................................................................................................................................................................................

Finished in 0.23073 seconds
194 examples, 0 failures
```

Thanks :)