### PR TITLE
Suppress Ruby 2.7 kwargs warnings

### DIFF
--- a/lib/associations/associations.rb
+++ b/lib/associations/associations.rb
@@ -3,10 +3,7 @@ module ActiveHash
 
     module ActiveRecordExtensions
 
-      def belongs_to(*args)
-        our_args = args.dup
-        options = our_args.extract_options!
-        name = our_args.shift
+      def belongs_to(name, scope = nil, **options)
         options = {:class_name => name.to_s.camelize }.merge(options)
         klass =
           begin


### PR DESCRIPTION
I've suppressed Ruby 2.7 kwargs warnings.

And I made belongs_to method the same interface to ActiveRecord one,
because it uses "super" inside its implementation.

If this pull request merged, these warnings are going to be suppressed.

```
/path/to/ruby/2.7.0/gems/active_hash-3.1.0/lib/associations/associations.rb:22: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

:memo: Separation of positional and keyword arguments in Ruby 3.0

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/