### PR TITLE
Implement ActiveRecord::RecordNotFound interface

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -1,6 +1,14 @@
 module ActiveHash
-
   class RecordNotFound < StandardError
+    attr_reader :model, :primary_key, :id
+
+    def initialize(message = nil, model = nil, primary_key = nil, id = nil)
+      @primary_key = primary_key
+      @model = model
+      @id = id
+
+      super(message)
+    end
   end
 
   class ReservedFieldError < StandardError

--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -36,7 +36,7 @@ module ActiveHash
     end
 
     def find_by!(options)
-      find_by(options) || (raise RecordNotFound.new("Couldn't find #{klass.name}"))
+      find_by(options) || (raise RecordNotFound.new("Couldn't find #{klass.name}", klass.name))
     end
 
     def find(id = nil, *args, &block)
@@ -48,11 +48,11 @@ module ActiveHash
         when Array
           id.map { |i| find(i) }
         when nil
-          raise RecordNotFound.new("Couldn't find #{klass.name} without an ID") unless block_given?
+          raise RecordNotFound.new("Couldn't find #{klass.name} without an ID", klass.name, "id") unless block_given?
           records.find(&block) # delegate to Enumerable#find if a block is given
         else
           find_by_id(id) || begin
-            raise RecordNotFound.new("Couldn't find #{klass.name} with ID=#{id}")
+            raise RecordNotFound.new("Couldn't find #{klass.name} with ID=#{id}", klass.name, "id", id)
           end
       end
     end

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -598,9 +598,15 @@ describe ActiveHash, "Base" do
       end
 
       it "raises ActiveHash::RecordNotFound when id not found" do
-        expect do
-          Country.find(0)
-        end.to raise_error(ActiveHash::RecordNotFound, /Couldn't find Country with ID=0/)
+        expect { 
+          Country.find(0) 
+        }.to raise_error(an_instance_of(ActiveHash::RecordNotFound)
+          .and having_attributes(
+            message: "Couldn't find Country with ID=0",
+            primary_key: 'id',
+            id: 0
+          )
+        )
       end
     end
 


### PR DESCRIPTION
We should include `model`, `id` and `primary_key`
attributes too to have the same interface as `ActiveRecord::RecordNotFound`.

This would make it possible to do something like this

```ruby
rescue_from ActiveRecord::RecordNotFound, ActiveHash::RecordNotFound, :render_not_found

def not_found
  render_error :record_not_found, message: "#{exception.model} not found.", status: :not_found
end
```