### PR TITLE
Call reload if @records is not defined

### DIFF
--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -103,7 +103,7 @@ module ActiveHash
     attr_writer :query_hash, :klass, :all_records, :records_dirty
 
     def records
-      if @records.nil? || records_dirty
+      if !defined?(@records) || @records.nil? || records_dirty
         reload
       else
         @records


### PR DESCRIPTION
Prevents `warning: instance variable @records not initialized`.

/cc @hktouw