### PR TITLE
Fix find_by_id with filter chain

### DIFF
--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -58,6 +58,8 @@ module ActiveHash
     end
 
     def find_by_id(id)
+      return where(id: id).first if query_hash.present?
+
       index = klass.send(:record_index)[id.to_s] # TODO: Make index in Base publicly readable instead of using send?
       index and records[index]
     end

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -683,6 +683,14 @@ describe ActiveHash, "Base" do
       it "finds the record with the specified id as a string" do
         Country.find_by_id("2").id.should == 2
       end
+
+      it "finds the record with a chained filter" do
+        Country.where(name: "Canada").find_by_id("2").id.should == 2
+      end
+
+      it "filters ecord with a chained filter" do
+        Country.where(name: "Canada").find_by_id("1").should be_nil
+      end
     end
 
     context "with string ids" do


### PR DESCRIPTION
The find_by_id method does leverage the record index. However, when a filter is applied we can not use the index
anymore as the order of the filter records does not match the order of index anymore. In this case, we should use the `where` filter instead.