### PR TITLE
Implement filter by RegEx

### DIFF
--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -133,7 +133,7 @@ module ActiveHash
         if match.kind_of?(Array)
           match.any? { |v| normalize(v) == normalize(record[col]) }
         else
-          normalize(record[col]) == normalize(match)
+          normalize(match) === normalize(record[col])
         end
       end
     end

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -299,6 +299,10 @@ describe ActiveHash, "Base" do
       expect(Country.where(:name => %w(US Canada)).map(&:name)).to match_array(%w(US Canada))
     end
 
+    it "filters records by a RegEx" do
+      expect(Country.where(:language => /Eng/).map(&:name)).to match_array(%w(US Canada))
+    end
+
     it "filters records for multiple symbol values" do
       expect(Country.where(:name => [:US, :Canada]).map(&:name)).to match_array(%w(US Canada))
     end


### PR DESCRIPTION
This commit implementing filtering by a Regular Expressions.

```ruby
Country.field :name
Country.field :language
Country.data = [
  {:id => 1, :name => "US", :language => 'English'},
  {:id => 2, :name => "Canada", :language => 'English'},
  {:id => 3, :name => "Mexico", :language => 'Spanish'}
]

Country.where(language: /En/).map(&:name)
```