### PR TITLE
Add model class and id to RecordNotFound error

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -1,6 +1,13 @@
 module ActiveHash
 
   class RecordNotFound < StandardError
+    attr_reader :model, :id
+
+    def initialize(message = nil, model = nil, id = nil)
+      @model = model
+      @id = id
+      super(message)
+    end
   end
 
   class ReservedFieldError < StandardError

--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -36,7 +36,7 @@ module ActiveHash
     end
 
     def find_by!(options)
-      find_by(options) || (raise RecordNotFound.new("Couldn't find #{klass.name}"))
+      find_by(options) || (raise RecordNotFound.new("Couldn't find #{klass.name}", klass))
     end
 
     def find(id = nil, *args, &block)
@@ -48,11 +48,11 @@ module ActiveHash
         when Array
           id.map { |i| find(i) }
         when nil
-          raise RecordNotFound.new("Couldn't find #{klass.name} without an ID") unless block_given?
+          raise RecordNotFound.new("Couldn't find #{klass.name} without an ID", klass) unless block_given?
           records.find(&block) # delegate to Enumerable#find if a block is given
         else
           find_by_id(id) || begin
-            raise RecordNotFound.new("Couldn't find #{klass.name} with ID=#{id}")
+            raise RecordNotFound.new("Couldn't find #{klass.name} with ID=#{id}", klass, id)
           end
       end
     end

--- a/spec/active_hash/base_spec.rb
+++ b/spec/active_hash/base_spec.rb
@@ -497,7 +497,10 @@ describe ActiveHash, "Base" do
       it { expect{ subject }.to raise_error ActiveHash::RecordNotFound }
       it "raises 'RecordNotFound' when passed a wrong id" do
         expect { Country.find_by!(id: 2) }.
-          to raise_error ActiveHash::RecordNotFound
+          to raise_error { |error|
+            expect(error).to be_a ActiveHash::RecordNotFound
+            expect(error.model).to eq Country
+          }
       end
 
       it "raises 'RecordNotFound' when passed wrong id and options" do
@@ -600,7 +603,12 @@ describe ActiveHash, "Base" do
       it "raises ActiveHash::RecordNotFound when id not found" do
         proc do
           Country.find(0)
-        end.should raise_error(ActiveHash::RecordNotFound, /Couldn't find Country with ID=0/)
+        end.should raise_error { |error|
+          expect(error).to be_a ActiveHash::RecordNotFound
+          expect(error.message).to match(/Couldn't find Country with ID=0/)
+          expect(error.model).to eq Country
+          expect(error.id).to eq 0
+        }
       end
     end
 


### PR DESCRIPTION
Added model class and id attributes to ActiveHash::RecordNotFound error for some situations that need more specific handling, like [ActiveRecord::RecordNotFound](https://github.com/rails/rails/blob/070d4afacd3e9721b7e3a4634e4d026b5fa2c32c/activerecord/lib/active_record/errors.rb#L60).