### PR TITLE
docs: Fix the example to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ class Country < ActiveFile::Base
 
   class << self
     def extension
-      ".super_secret"
+      "super_secret"
     end
 
     def load_file


### PR DESCRIPTION
Hi.

The following code of `ActiveFile::Base.full_path` shows that the first dot of file extension is not needed when a programmer overrides `ActiveFile::Base.extension`.
https://github.com/zilkey/active_hash/blob/1a07f3ea7b4920f35843010cc515be8c8695e612/lib/active_file/base.rb#L36

So I'm removing the first dot from the example code to go with the implementation of `ActiveFile::Base.full_path`.