### PR TITLE
Add size method to ActiveHash::Relation

### DIFF
--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -7,6 +7,9 @@ module ActiveHash
     delegate :empty?, :length, :first, :second, :third, :last, to: :records
     delegate :sample, to: :records
 
+    alias_method :count, :length
+    alias_method :size, :length
+
     def initialize(klass, all_records, query_hash = nil)
       self.klass = klass
       self.all_records = all_records
@@ -62,10 +65,6 @@ module ActiveHash
 
       index = klass.send(:record_index)[id.to_s] # TODO: Make index in Base publicly readable instead of using send?
       index and records[index]
-    end
-
-    def count
-      length
     end
 
     def pluck(*column_names)

--- a/spec/active_hash/relation_spec.rb
+++ b/spec/active_hash/relation_spec.rb
@@ -38,4 +38,16 @@ RSpec.describe ActiveHash::Relation do
       expect(array.second.id).to eq(2)
     end
   end
+
+  describe "#count" do
+    it "aliases length method" do
+      expect(subject.count).to eq(subject.length)
+    end
+  end
+
+  describe "#size" do
+    it "aliases length method" do
+      expect(subject.size).to eq(subject.length)
+    end
+  end
 end


### PR DESCRIPTION
Starting from Rails 6.1, Action View now tries to call `size` on collection to find out the collection's size while it's building the
cursor. This causes a compatibility issue when you try to render `ActiveHash::Relation` as a collection object, as `AH::R` did not respond to `#size`.

Error message:

    ActionView::Template::Error:
      undefined method `size' for #<ActiveHash::Relation:0x00007f9232aed640>
    # [GEM_HOME]/actionview-6.1.1/lib/action_view/renderer/collection_renderer.rb:48:in `size'
    # [GEM_HOME]/actionview-6.1.1/lib/action_view/renderer/collection_renderer.rb:178:in `collection_with_template'
    # [GEM_HOME]/actionview-6.1.1/lib/action_view/renderer/collection_renderer.rb:165:in `block in render_collection'
    # [GEM_HOME]/activesupport-6.1.1/lib/active_support/notifications.rb:203:in `block in instrument'
    # [GEM_HOME]/activesupport-6.1.1/lib/active_support/notifications/instrumenter.rb:24:in `instrument'
    # [GEM_HOME]/activesupport-6.1.1/lib/active_support/notifications.rb:203:in `instrument'
    # [GEM_HOME]/actionview-6.1.1/lib/action_view/renderer/collection_renderer.rb:147:in `render_collection'
    # [GEM_HOME]/actionview-6.1.1/lib/action_view/renderer/collection_renderer.rb:135:in `render_collection_derive_partial'
    # [GEM_HOME]/actionview-6.1.1/lib/action_view/renderer/renderer.rb:90:in `render_partial_to_object'
    # [GEM_HOME]/actionview-6.1.1/lib/action_view/renderer/renderer.rb:53:in `render_partial'
    # [GEM_HOME]/actionview-6.1.1/lib/action_view/helpers/rendering_helper.rb:45:in `render'

Example code that triggered the error:

    render Model.where(params: true)

Related code in Rails: https://github.com/rails/rails/blob/v6.1.1/actionview/lib/action_view/renderer/collection_renderer.rb#L47-L49

In this commit, I also switched `count` method to use `alias_method` as both `count` and `size` can be defined as an alias for `length`.