### PR TITLE
CI against Ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - "2.5.7"
   - "2.6.5"
   - "2.7.0"
+  - "3.0.0"
 gemfile:
   - gemfiles/rails_5.0.gemfile
   - gemfiles/rails_5.1.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,11 @@ matrix:
   exclude:
     - rvm: 2.4.9
       gemfile: gemfiles/rails_6.0.gemfile
+    - rvm: 3.0.0
+      gemfile: gemfiles/rails_5.0.gemfile
+    - rvm: 3.0.0
+      gemfile: gemfiles/rails_5.1.gemfile
+    - rvm: 3.0.0
+      gemfile: gemfiles/rails_5.2.gemfile
 
 script: "bundle exec rake spec"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -15,10 +15,4 @@ platform :ruby do
   gem 'sqlite3', '~> 1.3.0'
 end
 
-platforms :rbx do
-  gem 'racc'
-  gem 'rubysl', '~> 2.0'
-  gem 'psych'
-end
-
 gemspec :path => '../'

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -15,10 +15,4 @@ platform :ruby do
   gem 'sqlite3', '~> 1.3.0'
 end
 
-platforms :rbx do
-  gem 'racc'
-  gem 'rubysl', '~> 2.0'
-  gem 'psych'
-end
-
 gemspec :path => '../'

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -15,10 +15,4 @@ platform :ruby do
   gem 'sqlite3', '~> 1.3.0'
 end
 
-platforms :rbx do
-  gem 'racc'
-  gem 'rubysl', '~> 2.0'
-  gem 'psych'
-end
-
 gemspec :path => '../'

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -15,10 +15,4 @@ platform :ruby do
   gem 'sqlite3'
 end
 
-platforms :rbx do
-  gem 'racc'
-  gem 'rubysl', '~> 2.0'
-  gem 'psych'
-end
-
 gemspec :path => '../'

--- a/spec/associations/active_record_extensions_spec.rb
+++ b/spec/associations/active_record_extensions_spec.rb
@@ -180,7 +180,7 @@ unless SKIP_ACTIVE_RECORD
         it "doesn't raise any exception when the belongs_to association class can't be autoloaded" do
           # Simulate autoloader
           allow_any_instance_of(String).to receive(:constantize).and_raise(LoadError, "Unable to autoload constant NonExistent")
-          expect { School.belongs_to :city, {class_name: 'NonExistent'} }.not_to raise_error
+          expect { School.belongs_to :city, class_name: 'NonExistent' }.not_to raise_error
         end
       end
 


### PR DESCRIPTION
Hi.

I've tried some fix to make the CI status green against Ruby 3.
#### Removing `:rbx` specifications from `.gemfile`
It seems that the version specification of `rubysl` doesn't allow Ruby 3.0 (See: [the failing CI's log](https://travis-ci.org/github/zilkey/active_hash/jobs/757847933#L298) ).
I've tried to find some web source about 3.0 support of `rubysl` but I could not.

By the way, it also seems that our CI doesn't list `rbx` as its build target.

So I found it not necessary to get the problem fixed, and removed `platforms :rbx` specifications from all the `.gemfile`.
Is it OK ? I'm not certain if it's ok for this repository.

---
I'm glad if you see the commit comments to figure out what I did.
Thank you.