### PR TITLE
Correct fields with YAML aliases in array style

### DIFF
--- a/lib/active_yaml/aliases.rb
+++ b/lib/active_yaml/aliases.rb
@@ -5,6 +5,8 @@ module ActiveYaml
       base.extend(ClassMethods)
     end
 
+    ALIAS_KEY_REGEXP = /^\//i
+
     module ClassMethods
 
       def insert(record)
@@ -15,11 +17,11 @@ module ActiveYaml
         d = super
         if d.is_a?(Array)
           d.reject do |h|
-            h.keys.any? { |k| k.match(/^\//i) }
+            h.keys.any? { |k| k.match(ALIAS_KEY_REGEXP) }
           end
         else
           d.reject do |k, v|
-            v.kind_of? Hash and k.match(/^\//i)
+            v.kind_of? Hash and k.match(ALIAS_KEY_REGEXP)
           end
         end
       end
@@ -27,7 +29,7 @@ module ActiveYaml
     end
 
     def initialize(attributes={})
-      super unless attributes.keys.index { |k| k.to_s.match(/^\//i) }
+      super unless attributes.keys.index { |k| k.to_s.match(ALIAS_KEY_REGEXP) }
     end
   end
 

--- a/lib/active_yaml/aliases.rb
+++ b/lib/active_yaml/aliases.rb
@@ -5,7 +5,7 @@ module ActiveYaml
       base.extend(ClassMethods)
     end
 
-    ALIAS_KEY_REGEXP = /^\//i.freeze
+    ALIAS_KEY_REGEXP = /^\//.freeze
 
     module ClassMethods
 

--- a/lib/active_yaml/aliases.rb
+++ b/lib/active_yaml/aliases.rb
@@ -15,7 +15,7 @@ module ActiveYaml
 
       def raw_data
         d = super
-        if d.is_a?(Array)
+        if d.kind_of?(Array)
           d.reject do |h|
             h.keys.any? { |k| k.match(ALIAS_KEY_REGEXP) }
           end

--- a/lib/active_yaml/aliases.rb
+++ b/lib/active_yaml/aliases.rb
@@ -5,7 +5,7 @@ module ActiveYaml
       base.extend(ClassMethods)
     end
 
-    ALIAS_KEY_REGEXP = /^\//i
+    ALIAS_KEY_REGEXP = /^\//i.freeze
 
     module ClassMethods
 

--- a/lib/active_yaml/aliases.rb
+++ b/lib/active_yaml/aliases.rb
@@ -21,7 +21,7 @@ module ActiveYaml
           end
         else
           d.reject do |k, v|
-            v.kind_of? Hash and k.match(ALIAS_KEY_REGEXP)
+            v.kind_of?(Hash) && k.match(ALIAS_KEY_REGEXP)
           end
         end
       end

--- a/lib/active_yaml/aliases.rb
+++ b/lib/active_yaml/aliases.rb
@@ -12,8 +12,15 @@ module ActiveYaml
       end
 
       def raw_data
-        super.reject do |k, v|
-          v.kind_of? Hash and k.match(/^\//i)
+        d = super
+        if d.is_a?(Array)
+          d.reject do |h|
+            h.keys.any? { |k| k.match(/^\//i) }
+          end
+        else
+          d.reject do |k, v|
+            v.kind_of? Hash and k.match(/^\//i)
+          end
         end
       end
 

--- a/lib/active_yaml/aliases.rb
+++ b/lib/active_yaml/aliases.rb
@@ -27,10 +27,6 @@ module ActiveYaml
       end
 
     end
-
-    def initialize(attributes={})
-      super unless attributes.keys.index { |k| k.to_s.match(ALIAS_KEY_REGEXP) }
-    end
   end
 
 end

--- a/spec/active_yaml/aliases_spec.rb
+++ b/spec/active_yaml/aliases_spec.rb
@@ -34,9 +34,14 @@ describe ActiveYaml::Aliases do
     end
 
     describe 'keys starting with "/"' do
-      it 'excludes them' do
+      it 'excludes them from records' do
         models_including_aliases = model.all.select { |p| p.attributes.keys.include? :'/aliases' }
         expect(models_including_aliases).to be_empty
+      end
+
+      it 'excludes them from fields' do
+        model.all
+        expect(model.field_names).to match_array [:name, :flavor, :price]
       end
     end
   end
@@ -56,9 +61,14 @@ describe ActiveYaml::Aliases do
     end
 
     describe 'keys starting with "/"' do
-      it 'excludes them' do
+      it 'excludes them from records' do
         models_including_aliases = model.all.select { |p| p.attributes.keys.include? :'/aliases' }
         expect(models_including_aliases).to be_empty
+      end
+
+      it 'excludes them from fields' do
+        model.all
+        expect(model.field_names).to match_array [:name, :flavor, :price, :slogan]
       end
     end
   end


### PR DESCRIPTION
When you use aliases in array style YAML, keys used in the aliases are unexpectedly added to the fields.

With the array_products.yml in fixtures:

```yml
- /aliases:
  soda_flavor: &soda_flavor
    sweet
  soda_price: &soda_price
    1.0
  chip_flavor: &chip_flavor
    salty
  chip_price: &chip_price
    1.5

- id: 1
  name: Coke
  flavor: *soda_flavor
  price: *soda_price

- id: 2
  name: Pepsi
  flavor: *soda_flavor
  price: *soda_price

- id: 3
  name: Pringles
  flavor: *chip_flavor
  price: *chip_price

- id: 4
  name: ETA
  flavor: *chip_flavor
  price: *chip_price
```

### Before

```rb
ArrayProduct.all;
ArrayProduct.field_names
=> [:"/aliases", :chip_flavor, :chip_price, :flavor, :name, :price, :soda_flavor, :soda_price]
ArrayProduct.instance_methods(false).sort
=> [:"/aliases",
 :"/aliases=",
 :"/aliases?",
 :chip_flavor,
 :chip_flavor=,
 :chip_flavor?,
 :chip_price,
 :chip_price=,
 :chip_price?,
 :flavor,
 :flavor=,
 :flavor?,
 :name,
 :name=,
 :name?,
 :price,
 :price=,
 :price?,
 :soda_flavor,
 :soda_flavor=,
 :soda_flavor?,
 :soda_price,
 :soda_price=,
 :soda_price?]
```

### After

```rb
ArrayProduct.all;
ArrayProduct.field_names
=> [:flavor, :name, :price]
ArrayProduct.instance_methods(false).sort
=> [:flavor, :flavor=, :flavor?, :name, :name=, :name?, :price, :price=, :price?]
```
