### PR TITLE
Add ActiveHash::Relation#size method for compatibily

### DIFF
--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -68,6 +68,10 @@ module ActiveHash
       length
     end
 
+    def size
+      length
+    end
+
     def pluck(*column_names)
       column_names.map { |column_name| all.map(&column_name.to_sym) }.inject(&:zip)
     end

--- a/spec/active_hash/relation_spec.rb
+++ b/spec/active_hash/relation_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ActiveHash::Relation do
       ]
     end
   end
-  
+
   subject { model_class.all }
 
   describe '#sample' do
@@ -24,18 +24,30 @@ RSpec.describe ActiveHash::Relation do
       expect(records.sample(2).count).to eq(2)
     end
   end
-  
+
   describe '#to_ary' do
     it 'returns an array' do
       expect(subject.to_ary).to be_an(Array)
     end
-    
+
     it 'contains the same items as the relation' do
       array = subject.to_ary
-      
+
       expect(array.length).to eq(subject.count)
       expect(array.first.id).to eq(1)
       expect(array.second.id).to eq(2)
+    end
+  end
+
+  describe '#size' do
+    it 'returns an Integer' do
+      expect(subject.size).to be_an(Integer)
+    end
+
+    it 'returns the correct number of items of the relation' do
+      array = subject.to_ary
+
+      expect(array.size).to eq(2)
     end
   end
 end


### PR DESCRIPTION
With Rails 6.1.3.1 ActionView::Renderer::CollectionRenderer calls `size` method over collections. Adding the size method makes ActiveHash compatible with it.

This is the stacktrace from Rails after trying to render a collection of items (from ActiveHash, not an ActiveRecordRelation for example) in a view.

```
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/renderer/collection_renderer.rb:48:in `size'",
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/renderer/collection_renderer.rb:178:in `collection_with_template'",
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/renderer/collection_renderer.rb:162:in `block (2 levels) in render_collection'",
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/renderer/partial_renderer/collection_caching.rb:21:in `cache_collection_render'",
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/renderer/collection_renderer.rb:161:in `block in render_collection'",
 "/usr/local/bundle/gems/activesupport-6.1.3.1/lib/active_support/notifications.rb:203:in `block in instrument'",
 "/usr/local/bundle/gems/activesupport-6.1.3.1/lib/active_support/notifications/instrumenter.rb:24:in `instrument'",
 "/usr/local/bundle/gems/activesupport-6.1.3.1/lib/active_support/notifications.rb:203:in `instrument'",
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/renderer/collection_renderer.rb:147:in `render_collection'",
 "/usr/local/bundle/gems/jb-0.8.0/lib/jb/action_view_monkeys.rb:19:in `render_collection'",
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/renderer/collection_renderer.rb:119:in `render_collection_with_partial'",
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/renderer/renderer.rb:72:in `render_partial_to_object'",
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/renderer/renderer.rb:27:in `render_to_object'",
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/renderer/renderer.rb:22:in `render'",
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/helpers/rendering_helper.rb:38:in `block in render'",
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/base.rb:273:in `in_rendering_context'",
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/helpers/rendering_helper.rb:34:in `render'",
 "/opt/app/app/views/v1/opportunity_types/index.json.jb:3:in `_app_views_v__opportunity_types_index_json_jb__2175721135940786817_71520'",
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/base.rb:247:in `public_send'",
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/base.rb:247:in `_run'",
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/template.rb:154:in `block in render'",
 "/usr/local/bundle/gems/activesupport-6.1.3.1/lib/active_support/notifications.rb:205:in `instrument'",
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/template.rb:345:in `instrument_render_template'",
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/template.rb:152:in `render'",
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/renderer/template_renderer.rb:61:in `block (2 levels) in render_template'",
 "/usr/local/bundle/gems/activesupport-6.1.3.1/lib/active_support/notifications.rb:203:in `block in instrument'",
 "/usr/local/bundle/gems/activesupport-6.1.3.1/lib/active_support/notifications/instrumenter.rb:24:in `instrument'",
 "/usr/local/bundle/gems/activesupport-6.1.3.1/lib/active_support/notifications.rb:203:in `instrument'",
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/renderer/template_renderer.rb:56:in `block in render_template'",
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/renderer/template_renderer.rb:75:in `render_with_layout'",
 "/usr/local/bundle/gems/actionview-6.1.3.1/lib/action_view/renderer/template_renderer.rb:55:in `render_template'",
 "/usr/local/bundle/gems/jb-0.8.0/lib/jb/action_view_monkeys.rb:9:in `render_template'"
```