### PR TITLE
Add an expectation to a test

### DIFF
--- a/spec/associations/active_record_extensions_spec.rb
+++ b/spec/associations/active_record_extensions_spec.rb
@@ -177,7 +177,7 @@ unless SKIP_ACTIVE_RECORD
           expect(school.city).to eq(city)
         end
 
-        it "returns nil when the belongs_to association class can't be autoloaded" do
+        it "doesn't raise any exception when the belongs_to association class can't be autoloaded" do
           # Simulate autoloader
           allow_any_instance_of(String).to receive(:constantize).and_raise(LoadError, "Unable to autoload constant NonExistent")
           expect { School.belongs_to :city, {class_name: 'NonExistent'} }.not_to raise_error

--- a/spec/associations/active_record_extensions_spec.rb
+++ b/spec/associations/active_record_extensions_spec.rb
@@ -180,7 +180,7 @@ unless SKIP_ACTIVE_RECORD
         it "returns nil when the belongs_to association class can't be autoloaded" do
           # Simulate autoloader
           allow_any_instance_of(String).to receive(:constantize).and_raise(LoadError, "Unable to autoload constant NonExistent")
-          School.belongs_to :city, {class_name: 'NonExistent'}
+          expect { School.belongs_to :city, {class_name: 'NonExistent'} }.not_to raise_error
         end
       end
 


### PR DESCRIPTION
The original test works well enough as a test for [the commit](https://github.com/zilkey/active_hash/commit/209834d39f688597f0f85cebe69d30e8c6ae48c5) .

But it might be a little clearer for its readers if the test has its own expectation.
So I added an expectation that shows us what the commit did, tweaking its description as well.