### PR TITLE
Minor: reduce unnecessary check on id

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -446,7 +446,7 @@ module ActiveHash
     end
 
     def id
-      attributes[:id] ? attributes[:id] : nil
+      attributes[:id]
     end
 
     def id=(id)


### PR DESCRIPTION
Minor nit but...

no need to default a `nil` value to `nil`