### PR TITLE
Fix deadlock in belongs_to/has_many :through; support polymorphic source_type

### DIFF
--- a/lib/associations/associations.rb
+++ b/lib/associations/associations.rb
@@ -7,36 +7,48 @@ module ActiveHash
       end
 
       def has_many(association_id, scope = nil, **options, &extension)
+        super
+
         if options[:through]
           source_association_name = options[:source]&.to_s || association_id.to_s.singularize
 
-          through_klass = reflect_on_association(options[:through])&.klass
-          klass = through_klass&.reflect_on_association(source_association_name)&.klass
+          define_method(association_id) do
+            through_klass = self.class.reflect_on_association(options[:through])&.klass
+            source_klass = through_klass&.reflect_on_association(source_association_name)&.class_name&.safe_constantize
 
-          if klass && klass < ActiveHash::Base
-            define_method(association_id) do
-              join_models = send(options[:through])
-              join_models.flat_map do |join_model|
+            if source_klass && source_klass < ActiveHash::Base
+              send(options[:through]).flat_map do |join_model|
                 join_model.send(source_association_name)
               end.uniq
+            else
+              super()
             end
-
-            return
           end
         end
-
-        super
       end
 
       def belongs_to(name, scope = nil, **options)
         klass_name = options.key?(:class_name) ? options[:class_name] : name.to_s.camelize
-        klass = klass_name.safe_constantize
+        foreign_key = options[:foreign_key] || name.to_s.foreign_key
 
-        if klass && klass < ActiveHash::Base
-          options = { class_name: klass_name }.merge(options)
-          belongs_to_active_hash(name, options)
-        else
-          super
+        super
+
+        define_method(name) do
+          klass = klass_name.safe_constantize
+          if klass && klass < ActiveHash::Base
+            klass.send("find_by_#{klass.primary_key}", send(foreign_key))
+          else
+            super()
+          end
+        end
+
+        define_method("#{name}=") do |new_value|
+          klass = klass_name.safe_constantize
+          if klass && klass < ActiveHash::Base
+            send("#{foreign_key}=", new_value ? new_value.send(klass.primary_key) : nil)
+          else
+            super(new_value)
+          end
         end
       end
 

--- a/lib/associations/associations.rb
+++ b/lib/associations/associations.rb
@@ -12,16 +12,31 @@ module ActiveHash
         if options[:through]
           source_association_name = options[:source]&.to_s || association_id.to_s.singularize
 
-          define_method(association_id) do
-            through_klass = self.class.reflect_on_association(options[:through])&.klass
-            source_klass = through_klass&.reflect_on_association(source_association_name)&.class_name&.safe_constantize
+          if options[:source_type]
+            source_type = options[:source_type]
+            source_foreign_key = "#{source_association_name}_id"
 
-            if source_klass && source_klass < ActiveHash::Base
-              send(options[:through]).flat_map do |join_model|
-                join_model.send(source_association_name)
-              end.uniq
-            else
-              super()
+            define_method(association_id) do
+              klass = source_type.safe_constantize
+              if klass < ActiveHash::Base
+                ids = send(options[:through]).map { |jm| jm.send(source_foreign_key) }.compact.uniq
+                klass.where(id: ids)
+              else
+                super()
+              end
+            end
+          else
+            define_method(association_id) do
+              through_klass = self.class.reflect_on_association(options[:through])&.klass
+              reflection = through_klass&.reflect_on_association(source_association_name)
+              source_klass = reflection&.class_name&.safe_constantize
+
+              if source_klass && source_klass < ActiveHash::Base
+                ids = send(options[:through]).map { |jm| jm.send(reflection.foreign_key) }.compact.uniq
+                source_klass.where(source_klass.primary_key => ids)
+              else
+                super()
+              end
             end
           end
         end

--- a/spec/associations/active_record_extensions_spec.rb
+++ b/spec/associations/active_record_extensions_spec.rb
@@ -5,7 +5,7 @@ unless SKIP_ACTIVE_RECORD
 
     def define_ephemeral_class(name, superclass, &block)
       klass = Class.new(superclass)
-      Object.const_set(name, klass)
+      Kernel::silence_warnings { Object.const_set(name, klass) }
       klass.class_eval(&block) if block_given?
       @ephemeral_classes << name
     end

--- a/spec/associations/active_record_extensions_spec.rb
+++ b/spec/associations/active_record_extensions_spec.rb
@@ -5,7 +5,7 @@ unless SKIP_ACTIVE_RECORD
 
     def define_ephemeral_class(name, superclass, &block)
       klass = Class.new(superclass)
-      Kernel::silence_warnings { Object.const_set(name, klass) }
+      Object.const_set(name, klass)
       klass.class_eval(&block) if block_given?
       @ephemeral_classes << name
     end

--- a/spec/associations/active_record_extensions_spec.rb
+++ b/spec/associations/active_record_extensions_spec.rb
@@ -124,6 +124,47 @@ unless SKIP_ACTIVE_RECORD
 
     end
 
+    # Physician(AH) <-- Appointment(AR) --> Patient(AR)
+    # polymorphic: providerable on Appointment, source_type targets ActiveHash model
+    def define_polymorphic_doctor_classes
+      define_ephemeral_class(:Physician, ActiveHash::Base) do
+        include ActiveHash::Associations
+
+        self.data = [
+          {:id => 1, :name => "ikeda"},
+          {:id => 2, :name => "sato"}
+        ]
+      end
+
+      define_ephemeral_class(:Appointment, ActiveRecord::Base) do
+        establish_connection :adapter => "sqlite3", :database => ":memory:"
+        connection.create_table :appointments, force: true do |t|
+          t.references :providerable, polymorphic: true
+          t.references :patient
+        end
+
+        extend ActiveHash::Associations::ActiveRecordExtensions
+
+        # AR belongs_to (polymorphic)
+        belongs_to :providerable, polymorphic: true
+        # AR belongs_to
+        belongs_to :patient
+      end
+
+      define_ephemeral_class(:Patient, ActiveRecord::Base) do
+        establish_connection :adapter => "sqlite3", :database => ":memory:"
+        connection.create_table :patients, force: true do |t|
+        end
+
+        extend ActiveHash::Associations::ActiveRecordExtensions
+
+        # AR has_many
+        has_many :appointments
+        # AR has_many :through (source_type points to ActiveHash model)
+        has_many :physicians, through: :appointments, source: :providerable, source_type: "Physician"
+      end
+    end
+
     before do
       @ephemeral_classes = []
     end
@@ -283,6 +324,22 @@ unless SKIP_ACTIVE_RECORD
 
             expect(patient.doctors).to contain_exactly(physician)
           end
+        end
+      end
+
+      describe ":through with a polymorphic source and source_type" do
+        before { define_polymorphic_doctor_classes }
+
+        it "does not raise when defining the association" do
+          expect(Patient.instance_method(:physicians)).to be_a(UnboundMethod)
+        end
+
+        it "returns the correct ActiveHash records" do
+          physician = Physician.find(1)
+          patient = Patient.create!
+          Appointment.create!(providerable_type: "Physician", providerable_id: physician.id, patient_id: patient.id)
+
+          expect(patient.physicians).to contain_exactly(physician)
         end
       end
 


### PR DESCRIPTION
Resolving classes at definition time can deadlock in production. AR holds a schema lock and a class-load lock. Loading one class that triggers loading another will hit both locks and hang.

- `belongs_to` and `has_many :through` now resolve ActiveHash classes at runtime, avoiding the deadlock
- Handle polymorphic `has_many :through` with `source_type` (fixes #334)

Note: `belongs_to_active_hash` is unchanged and still available for direct use.

Thank you, @alexgriff, for the reproducer.