### PR TITLE
Fix nil FK queries, strict_where validation, field name conflict warnings

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -21,7 +21,7 @@ module ActiveHash
   end
 
   class Base
-    class_attribute :_data, :dirty, :default_attributes, :scopes
+    class_attribute :_data, :dirty, :default_attributes, :scopes, :strict_where
 
     if Object.const_defined?(:ActiveModel)
       extend ActiveModel::Naming
@@ -233,6 +233,13 @@ module ActiveHash
         field_name = field_name.to_sym
         if [:attributes].include?(field_name)
           raise ReservedFieldError.new("#{field_name} is a reserved field in ActiveHash.  Please use another name.")
+        end
+
+        if method_defined?(field_name) || private_method_defined?(field_name)
+          warn(
+            "ActiveHash: Field :#{field_name} on #{name} conflicts with an existing method. " \
+            "The field will not override the existing method, and accessing it may return unexpected results."
+          )
         end
       end
 

--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -66,6 +66,7 @@ module ActiveHash
     end
 
     def where!(conditions_hash, inverted = false)
+      validate_where_keys!(conditions_hash)
       self.conditions << Condition.new(conditions_hash)
       self
     end
@@ -195,6 +196,23 @@ module ActiveHash
     private
 
     attr_writer :conditions, :order_values, :klass, :all_records
+
+    def validate_where_keys!(conditions_hash)
+      return unless conditions_hash.is_a?(Hash)
+      return unless klass.respond_to?(:strict_where) && klass.strict_where
+
+      valid_fields = klass.field_names + [klass.primary_key.to_sym]
+      invalid_keys = conditions_hash.keys.map(&:to_sym) - valid_fields
+
+      if invalid_keys.any? && klass.respond_to?(:data) && klass.data.is_a?(Array)
+        data_keys = klass.data.flat_map(&:keys).map(&:to_sym).uniq
+        invalid_keys -= data_keys
+      end
+
+      if invalid_keys.any?
+        raise ArgumentError, "Unknown field(s): #{invalid_keys.map(&:to_s).join(', ')}. Valid fields are: #{valid_fields.map(&:to_s).join(', ')}"
+      end
+    end
 
     def apply_conditions(records, conditions)
       return records if conditions.blank?

--- a/lib/associations/associations.rb
+++ b/lib/associations/associations.rb
@@ -49,11 +49,16 @@ module ActiveHash
         super
 
         define_method(name) do
-          klass = klass_name.safe_constantize
-          if klass && klass < ActiveHash::Base
-            klass.send("find_by_#{klass.primary_key}", send(foreign_key))
+          fk_value = send(foreign_key)
+          if fk_value.nil?
+            nil
           else
-            super()
+            klass = klass_name.safe_constantize
+            if klass && klass < ActiveHash::Base
+              klass.send("find_by_#{klass.primary_key}", fk_value)
+            else
+              super()
+            end
           end
         end
 
@@ -78,7 +83,8 @@ module ActiveHash
         options[:shortcuts] = [options[:shortcuts]] unless options[:shortcuts].kind_of?(Array)
 
         define_method(association_id) do
-          options[:class_name].safe_constantize.send("find_by_#{options[:primary_key]}", send(options[:foreign_key]))
+          fk_value = send(options[:foreign_key])
+          fk_value.nil? ? nil : options[:class_name].safe_constantize.send("find_by_#{options[:primary_key]}", fk_value)
         end
 
         define_method("#{association_id}=") do |new_value|
@@ -179,7 +185,8 @@ module ActiveHash
           if scope.respond_to?(:scoped) && options[:conditions]
             scope = scope.scoped(:conditions => options[:conditions])
           end
-          scope.send("find_by_#{options[:foreign_key]}", send(options[:primary_key]))
+          pk_value = send(options[:primary_key])
+          pk_value.nil? ? nil : scope.send("find_by_#{options[:foreign_key]}", pk_value)
         end
       end
 
@@ -193,7 +200,8 @@ module ActiveHash
         field options[:foreign_key].to_sym
 
         define_method(association_id) do
-          options[:class_name].safe_constantize.send("find_by_#{options[:primary_key]}", send(options[:foreign_key]))
+          fk_value = send(options[:foreign_key])
+          fk_value.nil? ? nil : options[:class_name].safe_constantize.send("find_by_#{options[:primary_key]}", fk_value)
         end
 
         define_method("#{association_id}=") do |new_value|


### PR DESCRIPTION
## Summary

Three low-hanging fixes addressing open issues.

### Fixes #302 — belongs_to with nil foreign key makes useless query

When accessing a `belongs_to` association with a nil foreign key, ActiveHash was still calling `find_by_*` which triggers a DB query. ActiveRecord skips this query when the key is nil.

**Fix:** Early return `nil` when foreign key is nil in:
- `ActiveRecordExtensions#belongs_to`
- `belongs_to_active_hash`
- `Methods#belongs_to`
- `Methods#has_one`

No breaking change — nil key previously returned nil anyway after a useless query.

### Fixes #190 — `where(undefined_key: nil)` returns all records

`where()` with an undefined field silently returns all records because `read_attribute` returns nil for unknown keys, and nil == nil matches everything.

**Fix:** Opt-in `strict_where` class attribute. When enabled:
```ruby
class Country < ActiveHash::Base
  self.strict_where = true
  fields :name, :code
end

Country.where(typo_key: nil)
# => ArgumentError: Unknown field(s): typo_key. Valid fields are: id, name, code
```

Also validates against data keys for models that use undeclared fields via `data=`. Opt-in only — no breaking change.

### Fixes #184 — `field :display` silently returns nil

Rails adds `display` to Object. ActiveHash skips defining the method if one already exists, but gives no indication. Users get silent nil returns and confusing test failures.

**Fix:** `warn()` in `validate_field` when field name conflicts with an existing method:
```ruby
class TestHash < ActiveHash::Base
  field :display
  # => warning: ActiveHash: Field :display on TestHash conflicts with an existing method...
end
```

Additive warning only — no breaking change.

## Test Results

276 specs pass, 2 pre-existing sqlite3 adapter failures unrelated to these changes.
