### PR TITLE
Add exists? to Relation

### DIFF
--- a/lib/active_hash/base.rb
+++ b/lib/active_hash/base.rb
@@ -103,20 +103,6 @@ module ActiveHash
         end
       end
 
-      def exists?(args = :none)
-        if args.respond_to?(:id)
-          record_index[args.id.to_s].present?
-        elsif !args
-          false
-        elsif args == :none
-          all.present?
-        elsif args.is_a?(Hash)
-          all.where(args).present?
-        else
-          all.where(id: args.to_s).present?
-        end
-      end
-
       def insert(record)
         @records ||= []
         record[:id] ||= next_id
@@ -190,7 +176,7 @@ module ActiveHash
         relation
       end
 
-      delegate :where, :find_each, :find, :find_by, :find_by!, :find_by_id, :count, :pluck, :ids, :pick, :first, :last, :order, to: :all
+      delegate :exists?, :where, :find_each, :find, :find_by, :find_by!, :find_by_id, :count, :pluck, :ids, :pick, :first, :last, :order, to: :all
 
       def transaction
         yield

--- a/lib/active_hash/relation.rb
+++ b/lib/active_hash/relation.rb
@@ -152,6 +152,20 @@ module ActiveHash
       record if conditions.matches?(record)
     end
 
+    def exists?(args = :none)
+      if args.respond_to?(:id)
+        find_by_id(args.id).present?
+      elsif !args
+        false
+      elsif args == :none
+        records.present?
+      elsif args.is_a?(Hash)
+        where(args).present?
+      else
+        where(id: args.to_s).present?
+      end
+    end
+
     def count
       return super if block_given?
       length

--- a/spec/active_hash/relation_spec.rb
+++ b/spec/active_hash/relation_spec.rb
@@ -39,6 +39,94 @@ RSpec.describe ActiveHash::Relation do
     end
   end
 
+  describe '#exists?' do
+    context "when data are exists and no arguments is passed" do
+      it "return true" do
+        expect(subject.exists?).to be_truthy
+      end
+    end
+
+    context "when no data are exists and no arguments is passed" do
+      it "return false" do
+        expect(model_class.where(name: "Mexico").exists?).to be_falsy
+      end
+    end
+
+    context "when false is passed" do
+      it "return false" do
+        expect(subject.exists?(false)).to be_falsy
+      end
+    end
+
+    context "when nil is passed" do
+      it "return nil" do
+        expect(subject.exists?(nil)).to be_falsy
+      end
+    end
+
+    describe "with matches" do
+      context 'for a record argument' do
+        it "return true" do
+          expect(subject.exists?(model_class.new({ id: 1, name: "US" }))).to be_truthy
+        end
+      end
+
+      context "for an integer argument" do
+        it "return true" do
+          expect(subject.exists?(1)).to be_truthy
+        end
+      end
+
+      context "for a string argument" do
+        it "return true" do
+          expect(subject.exists?("1")).to be_truthy
+        end
+      end
+
+      context "for a hash argument" do
+        it "return true" do
+          expect(subject.exists?(name: "US")).to be_truthy
+        end
+      end
+    end
+
+    describe "without matches" do
+      context 'for a record argument' do
+        it "return false" do
+          expect(subject.exists?(model_class.new({ id: 3, name: "Mexico" }))).to be_falsy
+        end
+      end
+
+      context "for an integer argument" do
+        it "return false" do
+          expect(subject.exists?(3)).to be_falsy
+        end
+      end
+
+      context "for a string argument" do
+        it "return false" do
+          expect(subject.exists?("3")).to be_falsy
+        end
+      end
+
+      context "for a hash argument" do
+        it "return false" do
+          expect(subject.exists?(name: "Mexico")).to be_falsy
+        end
+      end
+    end
+
+    context "when ids are strings" do
+      before do
+        model_class.all.each { |record| record.id = record.name }
+      end
+
+      it "return true" do
+        expect(model_class.all.exists?("Canada")).to be_truthy
+      end
+    end
+  end
+
   describe '#count' do
     it 'supports a block arg' do
       expect(subject.count { |s| s.name == "US" }).to eq(1)


### PR DESCRIPTION
This PR adds exists? to `Relation` so that users can call the method after applying a scope to an ActiveHash model. 

This brings the behaviour inline with ActiveRecord.

### Problem
Calling `exists?` after apply scope/s results in NoMethodError being raised.
```
class Country < ActiveHash::Base
  scope :north_america, -> { where(continent: 'North America') }
  scope :south_america, -> { where(continent: 'South America') }

  self.data = [
    { id: 1, name: 'US', continent: 'North America' },
    { id: 2, name: 'Brazil', continent: 'South America' }
  ]
end
```
Without PR changes
```ruby
Country.exists? 1
# true
Country.north_america.exists? 1
# undefined method 'exists?' for an instance of ActiveHash::Relation (NoMethodError)
```
With PR changes
```ruby
Country.exists? 1
# true
Country.north_america.exists? 1
# true
```
#### initial comment

> ActiveRecord allows calling `exists?` on a relation, however ActiveHash currently only allows calling it on the base model. Adding the method to Relation provides functionality that those familiar with ActiveRecord expect.
> 
> I needed to monkey patch my app to get this behaviour and would appropriate it if you would consider including this in the next release. I would like to get rid of the monkey patch if possible